### PR TITLE
tutorials: re-execute 3 upstream FASTQ pipelines on v0.4 (PR 4c/5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,9 @@ epione_guide/tutorials/**/data-tobias-2020/
 # Cython build artifacts
 *.so
 *.pycepione_guide/tutorials/**/genome/
+# Upstream tutorial scratch dirs (FASTQ + ref + result, downloaded at notebook run time)
+epione_guide/tutorials/**/galaxy_atac_demo/
+epione_guide/tutorials/**/galaxy_chipseq_demo/
+epione_guide/tutorials/**/galaxy_cutrun_demo/
+epione_guide/tutorials/**/heme_footprint/
+epione_guide/tutorials/**/label_transfer/

--- a/epione_guide/tutorials/bulk/t_upstream_atac.ipynb
+++ b/epione_guide/tutorials/bulk/t_upstream_atac.ipynb
@@ -62,29 +62,24 @@
    "cell_type": "code",
    "execution_count": 1,
    "id": "d7938f15",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:37:53.577187Z",
+     "iopub.status.busy": "2026-04-25T21:37:53.577064Z",
+     "iopub.status.idle": "2026-04-25T21:37:57.181231Z",
+     "shell.execute_reply": "2026-04-25T21:37:57.180457Z"
+    }
+   },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.merge_pairs' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.make_seqtab' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.remove_chimeras' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 \ud83d\udd2c Starting plot initialization...\n",
-      "  \u251c\u2500 Apply Scanpy/matplotlib settings\n",
-      "  \u251c\u2500 Custom font setup\n",
-      "  \u251c\u2500 Suppress warnings\n",
-      "  \u251c\u2500 \n",
+      "└─ 🔬 Starting plot initialization...\n",
+      "  ├─ Apply Scanpy/matplotlib settings\n",
+      "  ├─ Custom font setup\n",
+      "  ├─ Suppress warnings\n",
+      "  ├─ \n",
       "___________      .__                      \n",
       "\\_   _____/_____ |__| ____   ____   ____  \n",
       " |    __)_\\____ \\|  |/  _ \\ /    \\_/ __ \\ \n",
@@ -92,8 +87,8 @@
       "/_______  /   __/|__|\\____/|___|  /\\___  >\n",
       "        \\/|__|                  \\/     \\/ \n",
       "\n",
-      "  \u251c\u2500 \ud83d\udd16 Version: 0.0.1rc1   \ud83d\udcda Tutorials: https://epione.readthedocs.io/\n",
-      "\u2514\u2500 \u2705 plot_set complete.\n",
+      "  ├─ 🔖 Version: 0.0.1rc1   📚 Tutorials: https://epione.readthedocs.io/\n",
+      "└─ ✅ plot_set complete.\n",
       "\n"
      ]
     }
@@ -160,22 +155,32 @@
    "cell_type": "code",
    "execution_count": 2,
    "id": "0bd31b60",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:37:57.182880Z",
+     "iopub.status.busy": "2026-04-25T21:37:57.182481Z",
+     "iopub.status.idle": "2026-04-25T21:37:57.189083Z",
+     "shell.execute_reply": "2026-04-25T21:37:57.188747Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  \u2717  bowtie2                    NOT FOUND\n",
-      "  \u2717  samtools                   NOT FOUND\n",
-      "  \u2717  bedtools                   NOT FOUND\n",
-      "  \u2717  macs2                      NOT FOUND\n"
+      "  ✓  bowtie2                    /scratch/users/steorra/env/omicdev/bin/bowtie2\n",
+      "  ✓  samtools                   /scratch/users/steorra/env/omicdev/bin/samtools\n",
+      "  ✓  bedtools                   /scratch/users/steorra/env/omicdev/bin/bedtools\n",
+      "  ✓  macs2                      /scratch/users/steorra/env/omicdev/bin/macs2\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'bowtie2': None, 'samtools': None, 'bedtools': None, 'macs2': None}"
+       "{'bowtie2': '/scratch/users/steorra/env/omicdev/bin/bowtie2',\n",
+       " 'samtools': '/scratch/users/steorra/env/omicdev/bin/samtools',\n",
+       " 'bedtools': '/scratch/users/steorra/env/omicdev/bin/bedtools',\n",
+       " 'macs2': '/scratch/users/steorra/env/omicdev/bin/macs2'}"
       ]
      },
      "execution_count": 2,
@@ -217,10 +222,10 @@
    "id": "20b14b1c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:10:23.158560Z",
-     "iopub.status.busy": "2026-04-23T13:10:23.158471Z",
-     "iopub.status.idle": "2026-04-23T13:10:23.165166Z",
-     "shell.execute_reply": "2026-04-23T13:10:23.164735Z"
+     "iopub.execute_input": "2026-04-25T21:37:57.190463Z",
+     "iopub.status.busy": "2026-04-25T21:37:57.190280Z",
+     "iopub.status.idle": "2026-04-25T21:38:02.483798Z",
+     "shell.execute_reply": "2026-04-25T21:38:02.483459Z"
     }
    },
    "outputs": [
@@ -228,40 +233,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "skip existing: SRR891268_chr22_enriched_R1.fastq.gz\n",
-      "skip existing: SRR891268_chr22_enriched_R2.fastq.gz\n"
+      "downloading SRR891268_chr22_enriched_R1.fastq.gz ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "downloading SRR891268_chr22_enriched_R2.fastq.gz ...\n"
      ]
     },
     {
      "data": {
-      "application/vnd.omicverse.dataframe+json": {
-       "dtypes": {
-        "fq1": "object",
-        "fq2": "object"
-       },
-       "name": null,
-       "ref": "obj:7f8c6e189360",
-       "shape": [
-        1,
-        2
-       ],
-       "table": {
-        "columns": [
-         "fq1",
-         "fq2"
-        ],
-        "data": [
-         [
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/fastq/SRR891268_chr22_enriched_R1.fastq.gz",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/fastq/SRR891268_chr22_enriched_R2.fastq.gz"
-         ]
-        ],
-        "index": [
-         "0"
-        ]
-       },
-       "type": "dataframe"
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -347,10 +330,10 @@
    "id": "9ea9b1f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:10:23.166159Z",
-     "iopub.status.busy": "2026-04-23T13:10:23.166011Z",
-     "iopub.status.idle": "2026-04-23T13:10:23.174515Z",
-     "shell.execute_reply": "2026-04-23T13:10:23.174115Z"
+     "iopub.execute_input": "2026-04-25T21:38:02.485624Z",
+     "iopub.status.busy": "2026-04-25T21:38:02.485426Z",
+     "iopub.status.idle": "2026-04-25T21:38:27.614345Z",
+     "shell.execute_reply": "2026-04-25T21:38:27.613783Z"
     }
    },
    "outputs": [
@@ -358,17 +341,832 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.54 ms, sys: 1.86 ms, total: 3.39 ms\n",
-      "Wall time: 4.99 ms\n"
+      "Settings:\n",
+      "  Output files: \"/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.*.bt2\"\n",
+      "  Line rate: 6 (line is 64 bytes)\n",
+      "  Lines per side: 1 (side is 64 bytes)\n",
+      "  Offset rate: 4 (one in 16)\n",
+      "  FTable chars: 10\n",
+      "  Strings: unpacked\n",
+      "  Max bucket size: default\n",
+      "  Max bucket size, sqrt multiplier: default\n",
+      "  Max bucket size, len divisor: 4\n",
+      "  Difference-cover sample period: 1024\n",
+      "  Endianness: little\n",
+      "  Actual local endianness: little\n",
+      "  Sanity checking: disabled\n",
+      "  Assertions: disabled\n",
+      "  Random seed: 0\n",
+      "  Sizeofs: void*:8, int:4, long:8, size_t:8\n",
+      "Input files DNA, FASTA:\n",
+      "  /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.fa\n",
+      "Reading reference sizes\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Building a SMALL index\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Time reading reference sizes: 00:00:00\n",
+      "Calculating joined length\n",
+      "Writing header\n",
+      "Reserving space for joined string\n",
+      "Joining reference sequences\n",
+      "  Time to join reference sequences: 00:00:00\n",
+      "bmax according to bmaxDivN setting: 9789944\n",
+      "Using parameters --bmax 7342458 --dcv 1024\n",
+      "  Doing ahead-of-time memory usage test\n",
+      "  Passed!  Constructing with these parameters: --bmax 7342458 --dcv 1024\n",
+      "Constructing suffix-array element generator\n",
+      "Building DifferenceCoverSample\n",
+      "  Building sPrime\n",
+      "  Building sPrimeOrder\n",
+      "  V-Sorting samples\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  V-Sorting samples time: 00:00:00\n",
+      "  Allocating rank array\n",
+      "  Ranking v-sort output\n",
+      "  Ranking v-sort output time: 00:00:01\n",
+      "  Invoking Larsson-Sadakane on ranks\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Invoking Larsson-Sadakane on ranks time: 00:00:00\n",
+      "  Sanity-checking and returning\n",
+      "Building samples\n",
+      "Reserving space for 12 sample suffixes\n",
+      "Generating random suffixes\n",
+      "QSorting 12 sample offsets, eliminating duplicates\n",
+      "QSorting sample offsets, eliminating duplicates time: 00:00:00\n",
+      "Multikey QSorting 12 samples\n",
+      "  (Using difference cover)\n",
+      "  Multikey QSorting samples time: 00:00:00\n",
+      "Calculating bucket sizes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Splitting and merging\n",
+      "  Splitting and merging time: 00:00:00\n",
+      "Avg bucket size: 4.89497e+06 (target: 7342457)\n",
+      "Converting suffix-array elements to index image\n",
+      "Allocating ftab, absorbFtab\n",
+      "Entering Ebwt loop\n",
+      "Getting block 1 of 8\n",
+      "  Reserving size (7342458) for bucket 1\n",
+      "  Calculating Z arrays for bucket 1\n",
+      "  Entering block accumulator loop for bucket 1:\n",
+      "  bucket 1: 10%\n",
+      "  bucket 1: 20%\n",
+      "  bucket 1: 30%\n",
+      "  bucket 1: 40%\n",
+      "  bucket 1: 50%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 1: 60%\n",
+      "  bucket 1: 70%\n",
+      "  bucket 1: 80%\n",
+      "  bucket 1: 90%\n",
+      "  bucket 1: 100%\n",
+      "  Sorting block of length 6109124 for bucket 1\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6109125 for bucket 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 2 of 8\n",
+      "  Reserving size (7342458) for bucket 2\n",
+      "  Calculating Z arrays for bucket 2\n",
+      "  Entering block accumulator loop for bucket 2:\n",
+      "  bucket 2: 10%\n",
+      "  bucket 2: 20%\n",
+      "  bucket 2: 30%\n",
+      "  bucket 2: 40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 2: 50%\n",
+      "  bucket 2: 60%\n",
+      "  bucket 2: 70%\n",
+      "  bucket 2: 80%\n",
+      "  bucket 2: 90%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 2: 100%\n",
+      "  Sorting block of length 4162165 for bucket 2\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 4162166 for bucket 2\n",
+      "Getting block 3 of 8\n",
+      "  Reserving size (7342458) for bucket 3\n",
+      "  Calculating Z arrays for bucket 3\n",
+      "  Entering block accumulator loop for bucket 3:\n",
+      "  bucket 3: 10%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 3: 20%\n",
+      "  bucket 3: 30%\n",
+      "  bucket 3: 40%\n",
+      "  bucket 3: 50%\n",
+      "  bucket 3: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 3: 70%\n",
+      "  bucket 3: 80%\n",
+      "  bucket 3: 90%\n",
+      "  bucket 3: 100%\n",
+      "  Sorting block of length 3242487 for bucket 3\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:00\n",
+      "Returning block of 3242488 for bucket 3\n",
+      "Getting block 4 of 8\n",
+      "  Reserving size (7342458) for bucket 4\n",
+      "  Calculating Z arrays for bucket 4\n",
+      "  Entering block accumulator loop for bucket 4:\n",
+      "  bucket 4: 10%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 20%\n",
+      "  bucket 4: 30%\n",
+      "  bucket 4: 40%\n",
+      "  bucket 4: 50%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 60%\n",
+      "  bucket 4: 70%\n",
+      "  bucket 4: 80%\n",
+      "  bucket 4: 90%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 100%\n",
+      "  Sorting block of length 5059508 for bucket 4\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:00\n",
+      "Returning block of 5059509 for bucket 4\n",
+      "Getting block 5 of 8\n",
+      "  Reserving size (7342458) for bucket 5\n",
+      "  Calculating Z arrays for bucket 5\n",
+      "  Entering block accumulator loop for bucket 5:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 10%\n",
+      "  bucket 5: 20%\n",
+      "  bucket 5: 30%\n",
+      "  bucket 5: 40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 50%\n",
+      "  bucket 5: 60%\n",
+      "  bucket 5: 70%\n",
+      "  bucket 5: 80%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 90%\n",
+      "  bucket 5: 100%\n",
+      "  Sorting block of length 2717729 for bucket 5\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:00\n",
+      "Returning block of 2717730 for bucket 5\n",
+      "Getting block 6 of 8\n",
+      "  Reserving size (7342458) for bucket 6\n",
+      "  Calculating Z arrays for bucket 6\n",
+      "  Entering block accumulator loop for bucket 6:\n",
+      "  bucket 6: 10%\n",
+      "  bucket 6: 20%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 30%\n",
+      "  bucket 6: 40%\n",
+      "  bucket 6: 50%\n",
+      "  bucket 6: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 70%\n",
+      "  bucket 6: 80%\n",
+      "  bucket 6: 90%\n",
+      "  bucket 6: 100%\n",
+      "  Sorting block of length 6052533 for bucket 6\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6052534 for bucket 6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 7 of 8\n",
+      "  Reserving size (7342458) for bucket 7\n",
+      "  Calculating Z arrays for bucket 7\n",
+      "  Entering block accumulator loop for bucket 7:\n",
+      "  bucket 7: 10%\n",
+      "  bucket 7: 20%\n",
+      "  bucket 7: 30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 7: 40%\n",
+      "  bucket 7: 50%\n",
+      "  bucket 7: 60%\n",
+      "  bucket 7: 70%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 7: 80%\n",
+      "  bucket 7: 90%\n",
+      "  bucket 7: 100%\n",
+      "  Sorting block of length 6696876 for bucket 7\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6696877 for bucket 7\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 8 of 8\n",
+      "  Reserving size (7342458) for bucket 8\n",
+      "  Calculating Z arrays for bucket 8\n",
+      "  Entering block accumulator loop for bucket 8:\n",
+      "  bucket 8: 10%\n",
+      "  bucket 8: 20%\n",
+      "  bucket 8: 30%\n",
+      "  bucket 8: 40%\n",
+      "  bucket 8: 50%\n",
+      "  bucket 8: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 8: 70%\n",
+      "  bucket 8: 80%\n",
+      "  bucket 8: 90%\n",
+      "  bucket 8: 100%\n",
+      "  Sorting block of length 5119348 for bucket 8\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 5119349 for bucket 8\n",
+      "Exited Ebwt loop\n",
+      "fchr[A]: 0\n",
+      "fchr[C]: 10382214\n",
+      "fchr[G]: 19542866\n",
+      "fchr[T]: 28789052\n",
+      "fchr[$]: 39159777\n",
+      "Exiting Ebwt::buildToDisk()\n",
+      "Returning from initFromVector\n",
+      "Wrote 17248347 bytes to primary EBWT file: /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.1.bt2.tmp\n",
+      "Wrote 9789952 bytes to secondary EBWT file: /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.2.bt2.tmp\n",
+      "Re-opening _in1 and _in2 as input streams\n",
+      "Returning from Ebwt constructor\n",
+      "Headers:\n",
+      "    len: 39159777\n",
+      "    bwtLen: 39159778\n",
+      "    sz: 9789945\n",
+      "    bwtSz: 9789945\n",
+      "    lineRate: 6\n",
+      "    offRate: 4\n",
+      "    offMask: 0xfffffff0\n",
+      "    ftabChars: 10\n",
+      "    eftabLen: 20\n",
+      "    eftabSz: 80\n",
+      "    ftabLen: 1048577\n",
+      "    ftabSz: 4194308\n",
+      "    offsLen: 2447487\n",
+      "    offsSz: 9789948\n",
+      "    lineSz: 64\n",
+      "    sideSz: 64\n",
+      "    sideBwtSz: 48\n",
+      "    sideBwtLen: 192\n",
+      "    numSides: 203958\n",
+      "    numLines: 203958\n",
+      "    ebwtTotLen: 13053312\n",
+      "    ebwtTotSz: 13053312\n",
+      "    color: 0\n",
+      "    reverse: 0\n",
+      "Total time for call to driver() for forward index: 00:00:12\n",
+      "Reading reference sizes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Time reading reference sizes: 00:00:00\n",
+      "Calculating joined length\n",
+      "Writing header\n",
+      "Reserving space for joined string\n",
+      "Joining reference sequences\n",
+      "  Time to join reference sequences: 00:00:00\n",
+      "  Time to reverse reference sequence: 00:00:00\n",
+      "bmax according to bmaxDivN setting: 9789944\n",
+      "Using parameters --bmax 7342458 --dcv 1024\n",
+      "  Doing ahead-of-time memory usage test\n",
+      "  Passed!  Constructing with these parameters: --bmax 7342458 --dcv 1024\n",
+      "Constructing suffix-array element generator\n",
+      "Building DifferenceCoverSample\n",
+      "  Building sPrime\n",
+      "  Building sPrimeOrder\n",
+      "  V-Sorting samples\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  V-Sorting samples time: 00:00:01\n",
+      "  Allocating rank array\n",
+      "  Ranking v-sort output\n",
+      "  Ranking v-sort output time: 00:00:00\n",
+      "  Invoking Larsson-Sadakane on ranks\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Invoking Larsson-Sadakane on ranks time: 00:00:00\n",
+      "  Sanity-checking and returning\n",
+      "Building samples\n",
+      "Reserving space for 12 sample suffixes\n",
+      "Generating random suffixes\n",
+      "QSorting 12 sample offsets, eliminating duplicates\n",
+      "QSorting sample offsets, eliminating duplicates time: 00:00:00\n",
+      "Multikey QSorting 12 samples\n",
+      "  (Using difference cover)\n",
+      "  Multikey QSorting samples time: 00:00:00\n",
+      "Calculating bucket sizes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Splitting and merging\n",
+      "  Splitting and merging time: 00:00:00\n",
+      "Avg bucket size: 5.59425e+06 (target: 7342457)\n",
+      "Converting suffix-array elements to index image\n",
+      "Allocating ftab, absorbFtab\n",
+      "Entering Ebwt loop\n",
+      "Getting block 1 of 7\n",
+      "  Reserving size (7342458) for bucket 1\n",
+      "  Calculating Z arrays for bucket 1\n",
+      "  Entering block accumulator loop for bucket 1:\n",
+      "  bucket 1: 10%\n",
+      "  bucket 1: 20%\n",
+      "  bucket 1: 30%\n",
+      "  bucket 1: 40%\n",
+      "  bucket 1: 50%\n",
+      "  bucket 1: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 1: 70%\n",
+      "  bucket 1: 80%\n",
+      "  bucket 1: 90%\n",
+      "  bucket 1: 100%\n",
+      "  Sorting block of length 6882572 for bucket 1\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6882573 for bucket 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 2 of 7\n",
+      "  Reserving size (7342458) for bucket 2\n",
+      "  Calculating Z arrays for bucket 2\n",
+      "  Entering block accumulator loop for bucket 2:\n",
+      "  bucket 2: 10%\n",
+      "  bucket 2: 20%\n",
+      "  bucket 2: 30%\n",
+      "  bucket 2: 40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 2: 50%\n",
+      "  bucket 2: 60%\n",
+      "  bucket 2: 70%\n",
+      "  bucket 2: 80%\n",
+      "  bucket 2: 90%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 2: 100%\n",
+      "  Sorting block of length 7217801 for bucket 2\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 7217802 for bucket 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 3 of 7\n",
+      "  Reserving size (7342458) for bucket 3\n",
+      "  Calculating Z arrays for bucket 3\n",
+      "  Entering block accumulator loop for bucket 3:\n",
+      "  bucket 3: 10%\n",
+      "  bucket 3: 20%\n",
+      "  bucket 3: 30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 3: 40%\n",
+      "  bucket 3: 50%\n",
+      "  bucket 3: 60%\n",
+      "  bucket 3: 70%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 3: 80%\n",
+      "  bucket 3: 90%\n",
+      "  bucket 3: 100%\n",
+      "  Sorting block of length 6398765 for bucket 3\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6398766 for bucket 3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 4 of 7\n",
+      "  Reserving size (7342458) for bucket 4\n",
+      "  Calculating Z arrays for bucket 4\n",
+      "  Entering block accumulator loop for bucket 4:\n",
+      "  bucket 4: 10%\n",
+      "  bucket 4: 20%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 30%\n",
+      "  bucket 4: 40%\n",
+      "  bucket 4: 50%\n",
+      "  bucket 4: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 70%\n",
+      "  bucket 4: 80%\n",
+      "  bucket 4: 90%\n",
+      "  bucket 4: 100%\n",
+      "  Sorting block of length 2716193 for bucket 4\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 2716194 for bucket 4\n",
+      "Getting block 5 of 7\n",
+      "  Reserving size (7342458) for bucket 5\n",
+      "  Calculating Z arrays for bucket 5\n",
+      "  Entering block accumulator loop for bucket 5:\n",
+      "  bucket 5: 10%\n",
+      "  bucket 5: 20%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 30%\n",
+      "  bucket 5: 40%\n",
+      "  bucket 5: 50%\n",
+      "  bucket 5: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 70%\n",
+      "  bucket 5: 80%\n",
+      "  bucket 5: 90%\n",
+      "  bucket 5: 100%\n",
+      "  Sorting block of length 5106643 for bucket 5\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 5106644 for bucket 5\n",
+      "Getting block 6 of 7\n",
+      "  Reserving size (7342458) for bucket 6\n",
+      "  Calculating Z arrays for bucket 6\n",
+      "  Entering block accumulator loop for bucket 6:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 10%\n",
+      "  bucket 6: 20%\n",
+      "  bucket 6: 30%\n",
+      "  bucket 6: 40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 50%\n",
+      "  bucket 6: 60%\n",
+      "  bucket 6: 70%\n",
+      "  bucket 6: 80%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 90%\n",
+      "  bucket 6: 100%\n",
+      "  Sorting block of length 6895232 for bucket 6\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6895233 for bucket 6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 7 of 7\n",
+      "  Reserving size (7342458) for bucket 7\n",
+      "  Calculating Z arrays for bucket 7\n",
+      "  Entering block accumulator loop for bucket 7:\n",
+      "  bucket 7: 10%\n",
+      "  bucket 7: 20%\n",
+      "  bucket 7: 30%\n",
+      "  bucket 7: 40%\n",
+      "  bucket 7: 50%\n",
+      "  bucket 7: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 7: 70%\n",
+      "  bucket 7: 80%\n",
+      "  bucket 7: 90%\n",
+      "  bucket 7: 100%\n",
+      "  Sorting block of length 3942565 for bucket 7\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 3942566 for bucket 7\n",
+      "Exited Ebwt loop\n",
+      "fchr[A]: 0\n",
+      "fchr[C]: 10382214\n",
+      "fchr[G]: 19542866\n",
+      "fchr[T]: 28789052\n",
+      "fchr[$]: 39159777\n",
+      "Exiting Ebwt::buildToDisk()\n",
+      "Returning from initFromVector\n",
+      "Wrote 17248347 bytes to primary EBWT file: /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.rev.1.bt2.tmp\n",
+      "Wrote 9789952 bytes to secondary EBWT file: /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.rev.2.bt2.tmp\n",
+      "Re-opening _in1 and _in2 as input streams\n",
+      "Returning from Ebwt constructor\n",
+      "Headers:\n",
+      "    len: 39159777\n",
+      "    bwtLen: 39159778\n",
+      "    sz: 9789945\n",
+      "    bwtSz: 9789945\n",
+      "    lineRate: 6\n",
+      "    offRate: 4\n",
+      "    offMask: 0xfffffff0\n",
+      "    ftabChars: 10\n",
+      "    eftabLen: 20\n",
+      "    eftabSz: 80\n",
+      "    ftabLen: 1048577\n",
+      "    ftabSz: 4194308\n",
+      "    offsLen: 2447487\n",
+      "    offsSz: 9789948\n",
+      "    lineSz: 64\n",
+      "    sideSz: 64\n",
+      "    sideBwtSz: 48\n",
+      "    sideBwtLen: 192\n",
+      "    numSides: 203958\n",
+      "    numLines: 203958\n",
+      "    ebwtTotLen: 13053312\n",
+      "    ebwtTotSz: 13053312\n",
+      "    color: 0\n",
+      "    reverse: 1\n",
+      "Total time for backward call to driver() for mirror index: 00:00:12\n",
+      "CPU times: user 203 ms, sys: 95.5 ms, total: 299 ms\n",
+      "Wall time: 25.1 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.3.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.3.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.4.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.4.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.1.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.1.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.2.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.2.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.rev.1.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.rev.1.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.rev.2.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.rev.2.bt2\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'fasta': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/ref/chr22.fa',\n",
-       " 'fai': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/ref/chr22.fa.fai',\n",
-       " 'chrom_sizes': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/ref/chr22.chrom.sizes',\n",
-       " 'ref_index': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/ref/chr22'}"
+       "{'fasta': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.fa',\n",
+       " 'fai': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.fa.fai',\n",
+       " 'chrom_sizes': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22.chrom.sizes',\n",
+       " 'ref_index': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/chr22'}"
       ]
      },
      "execution_count": 4,
@@ -423,10 +1221,10 @@
    "id": "499f2f73",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:10:23.175451Z",
-     "iopub.status.busy": "2026-04-23T13:10:23.175360Z",
-     "iopub.status.idle": "2026-04-23T13:10:35.728584Z",
-     "shell.execute_reply": "2026-04-23T13:10:35.728073Z"
+     "iopub.execute_input": "2026-04-25T21:38:27.615607Z",
+     "iopub.status.busy": "2026-04-25T21:38:27.615490Z",
+     "iopub.status.idle": "2026-04-25T21:38:43.684353Z",
+     "shell.execute_reply": "2026-04-25T21:38:43.683789Z"
     }
    },
    "outputs": [
@@ -456,7 +1254,20 @@
       "        389954 (96.17%) aligned 0 times\n",
       "        4843 (1.19%) aligned exactly 1 time\n",
       "        10705 (2.64%) aligned >1 times\n",
-      "31.65% overall alignment rate\n",
+      "31.65% overall alignment rate\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[bam_sort_core] merging from 0 files and 8 in-memory blocks...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
       "[bam_sort_core] merging from 0 files and 8 in-memory blocks...\n"
      ]
     },
@@ -471,7 +1282,6 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "[bam_sort_core] merging from 0 files and 8 in-memory blocks...\n",
       "[bam_sort_core] merging from 0 files and 64 in-memory blocks...\n"
      ]
     },
@@ -479,15 +1289,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 6.37 ms, sys: 33 ms, total: 39.4 ms\n",
-      "Wall time: 12.5 s\n"
+      "CPU times: user 2.97 ms, sys: 35.4 ms, total: 38.3 ms\n",
+      "Wall time: 16.1 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/fragments/SRR891268_galaxy_atac.filtered.bam',\n",
-       " 'frags': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/fragments/SRR891268_galaxy_atac.frags.tsv.gz'}"
+       "{'bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/fragments/SRR891268_galaxy_atac.filtered.bam',\n",
+       " 'frags': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/fragments/SRR891268_galaxy_atac.frags.tsv.gz'}"
       ]
      },
      "execution_count": 5,
@@ -564,10 +1374,10 @@
    "id": "b2142a26",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:10:35.729802Z",
-     "iopub.status.busy": "2026-04-23T13:10:35.729692Z",
-     "iopub.status.idle": "2026-04-23T13:11:01.453746Z",
-     "shell.execute_reply": "2026-04-23T13:11:01.453077Z"
+     "iopub.execute_input": "2026-04-25T21:38:43.685606Z",
+     "iopub.status.busy": "2026-04-25T21:38:43.685499Z",
+     "iopub.status.idle": "2026-04-25T21:39:10.088376Z",
+     "shell.execute_reply": "2026-04-25T21:39:10.087451Z"
     }
    },
    "outputs": [
@@ -575,15 +1385,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 25.9 s, sys: 533 ms, total: 26.5 s\n",
-      "Wall time: 25.7 s\n"
+      "CPU times: user 26.4 s, sys: 625 ms, total: 27.1 s\n",
+      "Wall time: 26.4 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'shift_bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/atac/SRR891268_galaxy_atac.shift.bam',\n",
-       " 'bigwig': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/atac/SRR891268_galaxy_atac.bw'}"
+       "{'shift_bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/atac/SRR891268_galaxy_atac.shift.bam',\n",
+       " 'bigwig': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/atac/SRR891268_galaxy_atac.bw'}"
       ]
      },
      "execution_count": 6,
@@ -655,10 +1465,10 @@
    "id": "d4a77c52",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:11:01.455423Z",
-     "iopub.status.busy": "2026-04-23T13:11:01.455294Z",
-     "iopub.status.idle": "2026-04-23T13:11:01.960450Z",
-     "shell.execute_reply": "2026-04-23T13:11:01.959974Z"
+     "iopub.execute_input": "2026-04-25T21:39:10.090185Z",
+     "iopub.status.busy": "2026-04-25T21:39:10.090037Z",
+     "iopub.status.idle": "2026-04-25T21:39:10.579909Z",
+     "shell.execute_reply": "2026-04-25T21:39:10.579345Z"
     }
    },
    "outputs": [
@@ -666,12 +1476,12 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: \n",
-      "# Command line: callpeak -t /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/atac/SRR891268_galaxy_atac.shift.bam -f BAMPE -g hs --keep-dup all -q 0.01 -n SRR891268_galaxy_atac --outdir /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/peaks --nomodel --call-summits\n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: \n",
+      "# Command line: callpeak -t /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/atac/SRR891268_galaxy_atac.shift.bam -f BAMPE -g hs --keep-dup all -q 0.01 -n SRR891268_galaxy_atac --outdir /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/peaks --nomodel --call-summits\n",
       "# ARGUMENTS LIST:\n",
       "# name = SRR891268_galaxy_atac\n",
       "# format = BAMPE\n",
-      "# ChIP-seq file = ['/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/atac/SRR891268_galaxy_atac.shift.bam']\n",
+      "# ChIP-seq file = ['/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/atac/SRR891268_galaxy_atac.shift.bam']\n",
       "# control file = None\n",
       "# effective genome size = 2.70e+09\n",
       "# band width = 300\n",
@@ -685,45 +1495,45 @@
       "# Paired-End mode is on\n",
       "# Searching for subpeak summits is on\n",
       " \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #1 read fragment files... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #1 read treatment fragments... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: 60475 fragments have been read. \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #1 mean fragment size is determined as 231.5 bp from treatment \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #1 fragment size = 231.5 \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #1  total fragments in treatment: 60475 \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #1 finished! \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #2 Build Peak Model... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #2 Skipped... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #3 Call peaks... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #3 Going to call summits inside each peak ... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #3 Pre-compute pvalue-qvalue table... \n"
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #1 read fragment files... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #1 read treatment fragments... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: 60475 fragments have been read. \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #1 mean fragment size is determined as 231.5 bp from treatment \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #1 fragment size = 231.5 \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #1  total fragments in treatment: 60475 \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #1 finished! \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #2 Build Peak Model... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #2 Skipped... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #3 Call peaks... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #3 Going to call summits inside each peak ... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #3 Pre-compute pvalue-qvalue table... \n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1.08 ms, sys: 924 \u03bcs, total: 2 ms\n",
-      "Wall time: 501 ms\n"
+      "CPU times: user 1.79 ms, sys: 1.04 ms, total: 2.83 ms\n",
+      "Wall time: 484 ms\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #3 Call peaks for each chromosome... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #4 Write output xls file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_peaks.xls \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #4 Write peak in narrowPeak format file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_peaks.narrowPeak \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: #4 Write summits bed file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_summits.bed \n",
-      "INFO  @ Thu, 23 Apr 2026 06:11:01: Done! \n"
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #3 Call peaks for each chromosome... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #4 Write output xls file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_peaks.xls \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #4 Write peak in narrowPeak format file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_peaks.narrowPeak \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: #4 Write summits bed file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_summits.bed \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:10: Done! \n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'narrowPeak': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_peaks.narrowPeak',\n",
-       " 'summits': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_summits.bed',\n",
-       " 'xls': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_peaks.xls'}"
+       "{'narrowPeak': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_peaks.narrowPeak',\n",
+       " 'summits': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_summits.bed',\n",
+       " 'xls': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/result/peaks/SRR891268_galaxy_atac_peaks.xls'}"
       ]
      },
      "execution_count": 7,
@@ -815,10 +1625,10 @@
    "id": "6a079473",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:11:01.961615Z",
-     "iopub.status.busy": "2026-04-23T13:11:01.961517Z",
-     "iopub.status.idle": "2026-04-23T13:11:02.053057Z",
-     "shell.execute_reply": "2026-04-23T13:11:02.052564Z"
+     "iopub.execute_input": "2026-04-25T21:39:10.581521Z",
+     "iopub.status.busy": "2026-04-25T21:39:10.581403Z",
+     "iopub.status.idle": "2026-04-25T21:39:10.675574Z",
+     "shell.execute_reply": "2026-04-25T21:39:10.674874Z"
     }
    },
    "outputs": [
@@ -826,8 +1636,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Load bigWig files\n",
-      "  \u2514\u2500 Loading ATAC...\n"
+      "└─ Load bigWig files\n",
+      "  └─ Loading ATAC...\n"
      ]
     },
     {
@@ -924,10 +1734,10 @@
    "id": "e77035f7",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:11:02.054233Z",
-     "iopub.status.busy": "2026-04-23T13:11:02.054070Z",
-     "iopub.status.idle": "2026-04-23T13:11:05.156722Z",
-     "shell.execute_reply": "2026-04-23T13:11:05.156187Z"
+     "iopub.execute_input": "2026-04-25T21:39:10.676932Z",
+     "iopub.status.busy": "2026-04-25T21:39:10.676810Z",
+     "iopub.status.idle": "2026-04-25T21:39:13.821647Z",
+     "shell.execute_reply": "2026-04-25T21:39:13.820938Z"
     }
    },
    "outputs": [
@@ -935,15 +1745,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Converting GFF to GTF: /scratch/users/steorra/data/snapatac2_cache/gencode_v41_GRCh38.gff3.gz -> /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/ref/gencode_v41_chr22.transcripts.gtf\n"
+      "└─ Converting GFF to GTF: /scratch/users/steorra/data/snapatac2_cache/gencode_v41_GRCh38.gff3.gz -> /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/gencode_v41_chr22.transcripts.gtf\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Wrote 3939 GTF records\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/ref/gencode_v41_chr22.transcripts.gtf 3939\n"
+      "└─ Wrote 3939 GTF records\n",
+      "/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/gencode_v41_chr22.transcripts.gtf 3939\n"
      ]
     }
    ],
@@ -972,10 +1782,10 @@
    "id": "bf51028a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:11:05.158012Z",
-     "iopub.status.busy": "2026-04-23T13:11:05.157899Z",
-     "iopub.status.idle": "2026-04-23T13:11:05.995241Z",
-     "shell.execute_reply": "2026-04-23T13:11:05.994750Z"
+     "iopub.execute_input": "2026-04-25T21:39:13.823070Z",
+     "iopub.status.busy": "2026-04-25T21:39:13.822882Z",
+     "iopub.status.idle": "2026-04-25T21:39:14.680694Z",
+     "shell.execute_reply": "2026-04-25T21:39:14.678477Z"
     }
    },
    "outputs": [
@@ -983,16 +1793,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Load bigWig files\n",
-      "  \u2514\u2500 Loading ATAC...\n",
-      "\u2514\u2500 Load GTF file\n",
-      "  \u251c\u2500 Reading GTF...\n",
-      "  \u2514\u2500 Reading GTF file from /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_atac_demo/ref/gencode_v41_chr22.transcripts.gtf...\n",
-      "  \u2514\u2500 GTF file read successfully\n",
-      "  \u2514\u2500 GTF loaded\n",
-      "\u2514\u2500 Compute matrix: ATAC\n",
-      "  \u251c\u2500 Prepare features\n",
-      "  \u251c\u2500 Build matrices\n"
+      "└─ Load bigWig files\n",
+      "  └─ Loading ATAC...\n",
+      "└─ Load GTF file\n",
+      "  ├─ Reading GTF...\n",
+      "  └─ Reading GTF file from /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_atac_demo/ref/gencode_v41_chr22.transcripts.gtf...\n",
+      "  └─ GTF file read successfully\n",
+      "  └─ GTF loaded\n",
+      "└─ Compute matrix: ATAC\n",
+      "  ├─ Prepare features\n",
+      "  ├─ Build matrices\n"
      ]
     },
     {
@@ -1008,7 +1818,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Chromosomes: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1/1 [00:00<00:00,  1.56chr/s]"
+      "Chromosomes: 100%|████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.55chr/s]"
      ]
     },
     {
@@ -1016,18 +1826,18 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Chromosomes: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1/1 [00:00<00:00,  1.56chr/s]"
+      "Chromosomes: 100%|████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.55chr/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  \u2514\u2500 Finalize\n",
-      "  \u2514\u2500 ATAC matrix finished\n",
-      "  \u2514\u2500 ATAC tss matrix in bw_tss_scores_dict[ATAC]\n",
-      "  \u2514\u2500 ATAC tes matrix in bw_tes_scores_dict[ATAC]\n",
-      "  \u2514\u2500 ATAC body matrix in bw_body_scores_dict[ATAC]\n"
+      "  └─ Finalize\n",
+      "  └─ ATAC matrix finished\n",
+      "  └─ ATAC tss matrix in bw_tss_scores_dict[ATAC]\n",
+      "  └─ ATAC tes matrix in bw_tes_scores_dict[ATAC]\n",
+      "  └─ ATAC body matrix in bw_body_scores_dict[ATAC]\n"
      ]
     },
     {
@@ -1124,10 +1934,10 @@
    "id": "6e638cc1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:11:05.996455Z",
-     "iopub.status.busy": "2026-04-23T13:11:05.996353Z",
-     "iopub.status.idle": "2026-04-23T13:11:05.998604Z",
-     "shell.execute_reply": "2026-04-23T13:11:05.998207Z"
+     "iopub.execute_input": "2026-04-25T21:39:14.682307Z",
+     "iopub.status.busy": "2026-04-25T21:39:14.682088Z",
+     "iopub.status.idle": "2026-04-25T21:39:14.684726Z",
+     "shell.execute_reply": "2026-04-25T21:39:14.684328Z"
     }
    },
    "outputs": [],

--- a/epione_guide/tutorials/bulk/t_upstream_chipseq.ipynb
+++ b/epione_guide/tutorials/bulk/t_upstream_chipseq.ipynb
@@ -55,39 +55,37 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "id": "02641eb1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:45:44.377803Z",
+     "iopub.status.busy": "2026-04-25T21:45:44.377716Z",
+     "iopub.status.idle": "2026-04-25T21:45:48.047512Z",
+     "shell.execute_reply": "2026-04-25T21:45:48.046958Z"
+    }
+   },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.merge_pairs' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.make_seqtab' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.remove_chimeras' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  \u2717  bowtie2                    NOT FOUND\n",
-      "  \u2717  samtools                   NOT FOUND\n",
-      "  \u2717  bedtools                   NOT FOUND\n",
-      "  \u2717  macs2                      NOT FOUND\n"
+      "  ✓  bowtie2                    /scratch/users/steorra/env/omicdev/bin/bowtie2\n",
+      "  ✓  samtools                   /scratch/users/steorra/env/omicdev/bin/samtools\n",
+      "  ✓  bedtools                   /scratch/users/steorra/env/omicdev/bin/bedtools\n",
+      "  ✓  macs2                      /scratch/users/steorra/env/omicdev/bin/macs2\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'bowtie2': None, 'samtools': None, 'bedtools': None, 'macs2': None}"
+       "{'bowtie2': '/scratch/users/steorra/env/omicdev/bin/bowtie2',\n",
+       " 'samtools': '/scratch/users/steorra/env/omicdev/bin/samtools',\n",
+       " 'bedtools': '/scratch/users/steorra/env/omicdev/bin/bedtools',\n",
+       " 'macs2': '/scratch/users/steorra/env/omicdev/bin/macs2'}"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 1,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -115,19 +113,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "id": "83651809",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:45:48.049625Z",
+     "iopub.status.busy": "2026-04-25T21:45:48.049145Z",
+     "iopub.status.idle": "2026-04-25T21:45:48.058122Z",
+     "shell.execute_reply": "2026-04-25T21:45:48.057675Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 \ud83d\udd2c Starting plot initialization...\n",
-      "  \u251c\u2500 Apply Scanpy/matplotlib settings\n",
-      "  \u251c\u2500 Custom font setup\n",
-      "  \u251c\u2500 Suppress warnings\n",
-      "  \u251c\u2500 \n",
+      "└─ 🔬 Starting plot initialization...\n",
+      "  ├─ Apply Scanpy/matplotlib settings\n",
+      "  ├─ Custom font setup\n",
+      "  ├─ Suppress warnings\n",
+      "  ├─ \n",
       "___________      .__                      \n",
       "\\_   _____/_____ |__| ____   ____   ____  \n",
       " |    __)_\\____ \\|  |/  _ \\ /    \\_/ __ \\ \n",
@@ -135,8 +140,8 @@
       "/_______  /   __/|__|\\____/|___|  /\\___  >\n",
       "        \\/|__|                  \\/     \\/ \n",
       "\n",
-      "  \u251c\u2500 \ud83d\udd16 Version: 0.0.1rc1   \ud83d\udcda Tutorials: https://epione.readthedocs.io/\n",
-      "\u2514\u2500 \u2705 plot_set complete.\n",
+      "  ├─ 🔖 Version: 0.0.1rc1   📚 Tutorials: https://epione.readthedocs.io/\n",
+      "└─ ✅ plot_set complete.\n",
       "\n"
      ]
     }
@@ -175,9 +180,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "a7ca9dbe",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:45:48.059158Z",
+     "iopub.status.busy": "2026-04-25T21:45:48.058989Z",
+     "iopub.status.idle": "2026-04-25T21:45:48.066642Z",
+     "shell.execute_reply": "2026-04-25T21:45:48.066262Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -192,49 +204,6 @@
     },
     {
      "data": {
-      "application/vnd.omicverse.dataframe+json": {
-       "dtypes": {
-        "fastq": "object",
-        "sample": "object"
-       },
-       "name": null,
-       "ref": "obj:7f7196fa6560",
-       "shape": [
-        4,
-        2
-       ],
-       "table": {
-        "columns": [
-         "sample",
-         "fastq"
-        ],
-        "data": [
-         [
-          "Tal1_R1",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/fastq/G1E_Tal1_R1.fastqsanger"
-         ],
-         [
-          "Tal1_R2",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/fastq/G1E_Tal1_R2.fastqsanger"
-         ],
-         [
-          "Input_R1",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/fastq/G1E_input_R1.fastqsanger"
-         ],
-         [
-          "Input_R2",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/fastq/G1E_input_R2.fastqsanger"
-         ]
-        ],
-        "index": [
-         "0",
-         "1",
-         "2",
-         "3"
-        ]
-       },
-       "type": "dataframe"
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -291,7 +260,7 @@
        "3  Input_R2  /scratch/users/steorra/analysis/omicverse_dev/..."
       ]
      },
-     "execution_count": 4,
+     "execution_count": 3,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -337,10 +306,10 @@
    "id": "1a3b8c10",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:05:38.456688Z",
-     "iopub.status.busy": "2026-04-23T13:05:38.456596Z",
-     "iopub.status.idle": "2026-04-23T13:05:39.058362Z",
-     "shell.execute_reply": "2026-04-23T13:05:39.057865Z"
+     "iopub.execute_input": "2026-04-25T21:45:48.067623Z",
+     "iopub.status.busy": "2026-04-25T21:45:48.067530Z",
+     "iopub.status.idle": "2026-04-25T21:45:48.622798Z",
+     "shell.execute_reply": "2026-04-25T21:45:48.622287Z"
     }
    },
    "outputs": [
@@ -348,17 +317,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 472 ms, sys: 122 ms, total: 594 ms\n",
-      "Wall time: 598 ms\n"
+      "CPU times: user 447 ms, sys: 90 ms, total: 537 ms\n",
+      "Wall time: 551 ms\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'fasta': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/ref/chr4.fa',\n",
-       " 'fai': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/ref/chr4.fa.fai',\n",
-       " 'chrom_sizes': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/ref/chr4.chrom.sizes',\n",
-       " 'ref_index': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/ref/chr4'}"
+       "{'fasta': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/ref/chr4.fa',\n",
+       " 'fai': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/ref/chr4.fa.fai',\n",
+       " 'chrom_sizes': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/ref/chr4.chrom.sizes',\n",
+       " 'ref_index': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/ref/chr4'}"
       ]
      },
      "execution_count": 4,
@@ -416,10 +385,10 @@
    "id": "6207f99a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:05:39.059436Z",
-     "iopub.status.busy": "2026-04-23T13:05:39.059339Z",
-     "iopub.status.idle": "2026-04-23T13:08:16.984544Z",
-     "shell.execute_reply": "2026-04-23T13:08:16.983931Z"
+     "iopub.execute_input": "2026-04-25T21:45:48.623995Z",
+     "iopub.status.busy": "2026-04-25T21:45:48.623895Z",
+     "iopub.status.idle": "2026-04-25T21:48:30.470113Z",
+     "shell.execute_reply": "2026-04-25T21:48:30.469434Z"
     }
    },
    "outputs": [
@@ -539,8 +508,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2min 5s, sys: 2.53 s, total: 2min 7s\n",
-      "Wall time: 2min 37s\n"
+      "CPU times: user 2min 7s, sys: 3.41 s, total: 2min 11s\n",
+      "Wall time: 2min 41s\n"
      ]
     },
     {
@@ -688,10 +657,10 @@
    "id": "6a2e884d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:08:16.986150Z",
-     "iopub.status.busy": "2026-04-23T13:08:16.985975Z",
-     "iopub.status.idle": "2026-04-23T13:09:21.271099Z",
-     "shell.execute_reply": "2026-04-23T13:09:21.270456Z"
+     "iopub.execute_input": "2026-04-25T21:48:30.471450Z",
+     "iopub.status.busy": "2026-04-25T21:48:30.471328Z",
+     "iopub.status.idle": "2026-04-25T21:49:36.063537Z",
+     "shell.execute_reply": "2026-04-25T21:49:36.062875Z"
     }
    },
    "outputs": [
@@ -699,17 +668,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 1min 2s, sys: 1.3 s, total: 1min 4s\n",
-      "Wall time: 1min 4s\n"
+      "CPU times: user 1min 3s, sys: 1.51 s, total: 1min 5s\n",
+      "Wall time: 1min 5s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'merged_chip_bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Tal1.filtered.bam',\n",
-       " 'merged_input_bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Input.filtered.bam',\n",
-       " 'merged_chip_bigwig': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Tal1.rpkm.bw',\n",
-       " 'merged_input_bigwig': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Input.rpkm.bw'}"
+       "{'merged_chip_bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/merged/Tal1.filtered.bam',\n",
+       " 'merged_input_bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/merged/Input.filtered.bam',\n",
+       " 'merged_chip_bigwig': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/merged/Tal1.rpkm.bw',\n",
+       " 'merged_input_bigwig': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/merged/Input.rpkm.bw'}"
       ]
      },
      "execution_count": 6,
@@ -770,7 +739,14 @@
    "cell_type": "code",
    "execution_count": 7,
    "id": "a619aab2-e824-454d-8752-7cf533a3b073",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:49:36.065013Z",
+     "iopub.status.busy": "2026-04-25T21:49:36.064893Z",
+     "iopub.status.idle": "2026-04-25T21:49:36.067249Z",
+     "shell.execute_reply": "2026-04-25T21:49:36.066830Z"
+    }
+   },
    "outputs": [],
    "source": [
     "merged_chip_bam='/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Tal1.filtered.bam'\n",
@@ -804,14 +780,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "131f1935",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:09:21.272449Z",
-     "iopub.status.busy": "2026-04-23T13:09:21.272339Z",
-     "iopub.status.idle": "2026-04-23T13:09:21.592354Z",
-     "shell.execute_reply": "2026-04-23T13:09:21.591868Z"
+     "iopub.execute_input": "2026-04-25T21:49:36.068213Z",
+     "iopub.status.busy": "2026-04-25T21:49:36.068120Z",
+     "iopub.status.idle": "2026-04-25T21:49:36.397848Z",
+     "shell.execute_reply": "2026-04-25T21:49:36.397337Z"
     },
     "scrolled": true
    },
@@ -820,13 +796,13 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: \n",
-      "# Command line: callpeak -t /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Tal1.filtered.bam -f BAM -g 156508116 --keep-dup all -q 0.01 -n G1E_Tal1 --outdir /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks -c /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Input.filtered.bam --call-summits\n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: \n",
+      "# Command line: callpeak -t /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/merged/Tal1.filtered.bam -f BAM -g 156508116 --keep-dup all -q 0.01 -n G1E_Tal1 --outdir /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/peaks -c /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/merged/Input.filtered.bam --call-summits\n",
       "# ARGUMENTS LIST:\n",
       "# name = G1E_Tal1\n",
       "# format = BAM\n",
-      "# ChIP-seq file = ['/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Tal1.filtered.bam']\n",
-      "# control file = ['/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/merged/Input.filtered.bam']\n",
+      "# ChIP-seq file = ['/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/merged/Tal1.filtered.bam']\n",
+      "# control file = ['/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/merged/Input.filtered.bam']\n",
       "# effective genome size = 1.57e+08\n",
       "# band width = 300\n",
       "# model fold = [5, 50]\n",
@@ -839,63 +815,63 @@
       "# Paired-End mode is off\n",
       "# Searching for subpeak summits is on\n",
       " \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #1 read tag files... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #1 read treatment tags... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: 13164 reads have been read. \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #1.2 read input tags... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: 43048 reads have been read. \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #1 tag size is determined as 40 bps \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #1 tag size = 40.0 \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #1  total tags in treatment: 13164 \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #1  total tags in control: 43048 \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #1 finished! \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #2 Build Peak Model... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #2 looking for paired plus/minus strand peaks... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #2 number of paired peaks: 232 \n",
-      "WARNING @ Thu, 23 Apr 2026 06:09:21: Fewer paired peaks (232) than 1000! Model may not be build well! Lower your MFOLD parameter may erase this warning. Now I will use 232 pairs to build model! \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: start model_add_line... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: start X-correlation... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: end of X-cor \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #2 finished! \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #2 predicted fragment length is 37 bps \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #2 alternative fragment length(s) may be 37,82,102,145,184,215,235,303,351,409,486,526,554 bps \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #2.2 Generate R script for model : /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks/G1E_Tal1_model.r \n",
-      "WARNING @ Thu, 23 Apr 2026 06:09:21: #2 Since the d (37) calculated from paired-peaks are smaller than 2*tag length, it may be influenced by unknown sequencing problem! \n",
-      "WARNING @ Thu, 23 Apr 2026 06:09:21: #2 You may need to consider one of the other alternative d(s): 37,82,102,145,184,215,235,303,351,409,486,526,554 \n",
-      "WARNING @ Thu, 23 Apr 2026 06:09:21: #2 You can restart the process with --nomodel --extsize XXX with your choice or an arbitrary number. Nontheless, MACS will continute computing. \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #3 Call peaks... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #3 Going to call summits inside each peak ... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #3 Pre-compute pvalue-qvalue table... \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #3 Call peaks for each chromosome... \n"
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #1 read tag files... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #1 read treatment tags... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: 13164 reads have been read. \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #1.2 read input tags... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: 43048 reads have been read. \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #1 tag size is determined as 40 bps \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #1 tag size = 40.0 \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #1  total tags in treatment: 13164 \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #1  total tags in control: 43048 \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #1 finished! \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #2 Build Peak Model... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #2 looking for paired plus/minus strand peaks... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #2 number of paired peaks: 232 \n",
+      "WARNING @ Sat, 25 Apr 2026 14:49:36: Fewer paired peaks (232) than 1000! Model may not be build well! Lower your MFOLD parameter may erase this warning. Now I will use 232 pairs to build model! \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: start model_add_line... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: start X-correlation... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: end of X-cor \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #2 finished! \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #2 predicted fragment length is 37 bps \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #2 alternative fragment length(s) may be 37,82,102,145,184,215,235,303,351,409,486,526,554 bps \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #2.2 Generate R script for model : /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/peaks/G1E_Tal1_model.r \n",
+      "WARNING @ Sat, 25 Apr 2026 14:49:36: #2 Since the d (37) calculated from paired-peaks are smaller than 2*tag length, it may be influenced by unknown sequencing problem! \n",
+      "WARNING @ Sat, 25 Apr 2026 14:49:36: #2 You may need to consider one of the other alternative d(s): 37,82,102,145,184,215,235,303,351,409,486,526,554 \n",
+      "WARNING @ Sat, 25 Apr 2026 14:49:36: #2 You can restart the process with --nomodel --extsize XXX with your choice or an arbitrary number. Nontheless, MACS will continute computing. \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #3 Call peaks... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #3 Going to call summits inside each peak ... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #3 Pre-compute pvalue-qvalue table... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #3 Call peaks for each chromosome... \n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 167 \u03bcs, sys: 2 ms, total: 2.17 ms\n",
-      "Wall time: 316 ms\n"
+      "CPU times: user 1.36 ms, sys: 1.01 ms, total: 2.38 ms\n",
+      "Wall time: 326 ms\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #4 Write output xls file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.xls \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #4 Write peak in narrowPeak format file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.narrowPeak \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: #4 Write summits bed file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks/G1E_Tal1_summits.bed \n",
-      "INFO  @ Thu, 23 Apr 2026 06:09:21: Done! \n"
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #4 Write output xls file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.xls \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #4 Write peak in narrowPeak format file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.narrowPeak \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: #4 Write summits bed file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/peaks/G1E_Tal1_summits.bed \n",
+      "INFO  @ Sat, 25 Apr 2026 14:49:36: Done! \n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'narrowPeak': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.narrowPeak',\n",
-       " 'summits': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks/G1E_Tal1_summits.bed',\n",
-       " 'xls': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.xls'}"
+       "{'narrowPeak': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.narrowPeak',\n",
+       " 'summits': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/peaks/G1E_Tal1_summits.bed',\n",
+       " 'xls': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.xls'}"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -921,9 +897,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 9,
    "id": "7fd9ebdf-bdde-4f3c-a570-8e8e7f5c11ef",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:49:36.398935Z",
+     "iopub.status.busy": "2026-04-25T21:49:36.398829Z",
+     "iopub.status.idle": "2026-04-25T21:49:36.400833Z",
+     "shell.execute_reply": "2026-04-25T21:49:36.400433Z"
+    }
+   },
    "outputs": [],
    "source": [
     "peak_paths={'narrowPeak': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/result/peaks/G1E_Tal1_peaks.narrowPeak',\n",
@@ -943,17 +926,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "9e5100e7",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:49:36.401725Z",
+     "iopub.status.busy": "2026-04-25T21:49:36.401636Z",
+     "iopub.status.idle": "2026-04-25T21:49:36.724715Z",
+     "shell.execute_reply": "2026-04-25T21:49:36.724235Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Load bigWig files\n",
-      "  \u251c\u2500 Loading Tal1 ChIP...\n",
-      "  \u2514\u2500 Loading Input...\n"
+      "└─ Load bigWig files\n",
+      "  ├─ Loading Tal1 ChIP...\n",
+      "  └─ Loading Input...\n"
      ]
     },
     {
@@ -963,7 +953,7 @@
        " array([<Axes: ylabel='Tal1 ChIP'>, <Axes: >], dtype=object))"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     },
@@ -1034,37 +1024,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 11,
    "id": "d7aa60fd",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:09:21.912700Z",
-     "iopub.status.busy": "2026-04-23T13:09:21.912536Z",
-     "iopub.status.idle": "2026-04-23T13:09:26.002300Z",
-     "shell.execute_reply": "2026-04-23T13:09:26.001720Z"
+     "iopub.execute_input": "2026-04-25T21:49:36.725812Z",
+     "iopub.status.busy": "2026-04-25T21:49:36.725707Z",
+     "iopub.status.idle": "2026-04-25T21:49:38.927784Z",
+     "shell.execute_reply": "2026-04-25T21:49:38.927237Z"
     }
    },
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Downloading file 'gencode_vM25_GRCm38.gff3.gz' from 'https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_mouse/release_M25/gencode.vM25.basic.annotation.gff3.gz' to '/tmp/snapatac2'.\n"
+      "└─ Converting GFF to GTF: /tmp/snapatac2/gencode_vM25_GRCm38.gff3.gz -> /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/ref/gencode_vM25_chr4.transcripts.gtf\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Converting GFF to GTF: /tmp/snapatac2/gencode_vM25_GRCm38.gff3.gz -> /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/ref/gencode_vM25_chr4.transcripts.gtf\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "\u2514\u2500 Wrote 7035 GTF records\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/ref/gencode_vM25_chr4.transcripts.gtf 7035\n"
+      "└─ Wrote 7035 GTF records\n",
+      "/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/ref/gencode_vM25_chr4.transcripts.gtf 7035\n"
      ]
     }
    ],
@@ -1087,52 +1070,66 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "id": "7ec1883a-65dd-49ac-9e87-bcb810e7d89b",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "CHR4_GTF='/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/ref/gencode_vM25_chr4.transcripts.gtf'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "80d233ac",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-04-25T21:49:38.928948Z",
+     "iopub.status.busy": "2026-04-25T21:49:38.928839Z",
+     "iopub.status.idle": "2026-04-25T21:49:40.307400Z",
+     "shell.execute_reply": "2026-04-25T21:49:40.306961Z"
+    }
+   },
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Load bigWig files\n",
-      "  \u2514\u2500 Loading Tal1 ChIP...\n",
-      "\u2514\u2500 Load GTF file\n",
-      "  \u251c\u2500 Reading GTF...\n",
-      "  \u2514\u2500 Reading GTF file from /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_chipseq_demo/ref/gencode_vM25_chr4.transcripts.gtf...\n",
-      "  \u2514\u2500 GTF file read successfully\n",
-      "  \u2514\u2500 GTF loaded\n",
-      "\u2514\u2500 Compute matrix: Tal1 ChIP\n",
-      "  \u251c\u2500 Prepare features\n",
-      "  \u251c\u2500 Build matrices\n"
+      "└─ Load bigWig files\n",
+      "  └─ Loading Tal1 ChIP...\n",
+      "└─ Load GTF file\n",
+      "  ├─ Reading GTF...\n",
+      "  └─ Reading GTF file from /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_chipseq_demo/ref/gencode_vM25_chr4.transcripts.gtf...\n",
+      "  └─ GTF file read successfully\n",
+      "  └─ GTF loaded\n",
+      "└─ Compute matrix: Tal1 ChIP\n",
+      "  ├─ Prepare features\n",
+      "  ├─ Build matrices\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Chromosomes: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1/1 [00:01<00:00,  1.54s/chr]"
+      "\r",
+      "Chromosomes:   0%|                                                                                                | 0/1 [00:00<?, ?chr/s]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Chromosomes: 100%|████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.16s/chr]"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\r",
+      "Chromosomes: 100%|████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:01<00:00,  1.16s/chr]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  \u2514\u2500 Finalize\n",
-      "  \u2514\u2500 Tal1 ChIP matrix finished\n",
-      "  \u2514\u2500 Tal1 ChIP tss matrix in bw_tss_scores_dict[Tal1 ChIP]\n",
-      "  \u2514\u2500 Tal1 ChIP tes matrix in bw_tes_scores_dict[Tal1 ChIP]\n",
-      "  \u2514\u2500 Tal1 ChIP body matrix in bw_body_scores_dict[Tal1 ChIP]\n"
+      "  └─ Finalize\n",
+      "  └─ Tal1 ChIP matrix finished\n",
+      "  └─ Tal1 ChIP tss matrix in bw_tss_scores_dict[Tal1 ChIP]\n",
+      "  └─ Tal1 ChIP tes matrix in bw_tes_scores_dict[Tal1 ChIP]\n",
+      "  └─ Tal1 ChIP body matrix in bw_body_scores_dict[Tal1 ChIP]\n"
      ]
     },
     {
@@ -1149,39 +1146,9 @@
        " <Axes: title={'center': 'Tal1 ChIP TSS mean'}>)"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAKbCAYAAADVFWC4AAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAYmwAAGJsBSXWDlAAAbrBJREFUeJztnQecFOX5x9/dvV7g6CAoRRApggKCYkdiB7uiiSUWBPs/iRo1VkxQMWrUqAF7RdRYUCwxaizYO1ZQQClKkaNcL/v//J6Zd3Z2tu/t3d579/v6WffYnZmdnZ35vc8871N8wWAwqAghhBiDP9s7QAghJDUo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMg8JNCCGGQeEmhJD2Jtz33Xef8vl8KT+uvPLKlD8L62DdQw45JOGyn332mcrNzVVnn322aipffvmlOv/889XIkSNVSUmJysvLU1tttZWaPHmyeuyxx1Sskub6u3744Ycpfd7ee+8t65188slhr7/++usxj6ff71eFhYVq6623lv16/PHHY+5Xc/1+r776quzztttuq4qLi1VpaakaOHCgOvHEE9WCBQsS7svixYvVH//4RzVixAhVVlamCgoK5Pvg9549e7aqra1N6TguW7bM2d9169ap1syvv/6qfvnll2zvBjGEnKZuoEePHmq33XaLehGuWbNGdejQQe2www4R72+zzTaquVi/fr06/vjjVX19fZO2g/Uvvvhi9fe//11EMCcnR/YbgvTDDz+o+fPny+OWW25RTz75pOrZs6dqKcaMGaPy8/PDXquurlY//vijs1/HHHOMevTRR0XUm/P3a2hoUKeccop64IEHnG0OHTpUVVVVqeXLl6sHH3xQHgcddJB64oknZIDx8s9//lP94Q9/EHHG8YX4Y7+x/vPPPy+PG264QQYADAZtiTvuuEP95S9/kXMIx46QhASbiZNOOgnmXnCvvfbK2DavuOIK2ebBBx8cc5mffvopuNNOO8lyeJx11llpfVZ9fX1w3333lW106dIleNNNNwUrKyud9xsaGoKPPvpocKuttpJlhg0bFty8eXPYNvQ+fPDBByl9No4Z1sMxdPPaa68521y6dGnUdbFft9xyi7Pc7bffHmzu3+/SSy+VZfv27Rt8++23I/bn4YcfDnbu3FmWOe644yLWf/nll4M+ny+Yl5cXfOCBB4J1dXVh72ObI0eOlPUHDBgQrKqqSuo74Bjp47B27dpga6W4uFj2Eb8vIcnQpnzcTz31lBo1apT65JNPmrytGTNmqP/+97+qa9eu6rXXXhNXidtShDU4ZcoUcQ/ALQB3CtbJNtivc845Rx199NHy79tuu61ZP6+yslL94x//kL/nzp2rxo8fH7E/uPu59957nWW++eabsGVmzpwpdzRXXXWVOuGEE+TOxg22iTsIWP+407n//vub9TsR0tppM8J94IEHqiOOOEKtXbtWHX744erII49Me1u4Pf/rX/8qf19//fVRXQWawYMHq3PPPVf+vvPOO8Vd0RrAMQBfffWV2rJlS7N9zrfffivbh0DDfROLSZMmiRsAAv3++++HvffRRx/J87hx42KuD1/3/vvvL3+/9957Gdt/Qkwkq8L99ddfqzPPPFP8obCmMOnXq1cvmVx74YUXUtrWO++8I+vCz/rvf/9bJhHTBRN28G9DaGABJuKss85SDz/8sFjdmFCLBnzNu+++u/hv8V1hRWKd5qJjx47O35s3b262z8EEMGhsbFQvvvhizOUwQfi///1PfOf6bsC7Dfix43HTTTfJQHTjjTemvJ/ww99+++1q9OjRqqioSHXu3FlNnDgx7j7jzuDUU09Vffv2lfkE3H3BQHjuuediroNJUEzcYhDCZ+C7denSRe2xxx7ix3fPu+jJ9oqKCvn3PvvsI//G+ed+/5prrpG5i9///vdyjuPOD9eMvtMBOO933nln+W6dOnVShx12WMSdTbrXnd4P+OFxx4PfD98J5zKOJ3z0TZ1PIikSbCYS+Ugfe+yxYG5uriwD/+eoUaOC2223nfg5Y/ln4/m477rrrmBFRUXE56fj495jjz1k3WOOOSbYFPT30Nvr1KmTfM+ysjLnPXynTPq4NTfffLMsV1BQEKytrW02Hzf80VtvvbUsC1/tn//85+CiRYtS+iz4vbE+/NzHH3+8fE/MMTQVt49b/wbdu3eXOZCSkhLnvXvuuSdiXcxf6HMRy2Id/T3xOPPMMyPW+eqrr4I9e/aU9wsLC4PDhw8PjhgxIlhaWuqsd+yxxzrL33333cHddtst6Pf75T0sj38vWLAg7HyfMmWKnDu4XuDr79Wrl7O9q666SvbF/d1ycnLk3127dg2uWbMmY9cd9gPzPXpOZ/Dgwc46Bx10UNJzD6TpZEW4MVHUoUMHeX/mzJlhk1E///xz8IADDpD3cBE0NjamNDmZCeHu1q2brHvNNdcEm4I+qfGYMWNGsLq6Wl7H8wknnCCv4yLauHFjRoW7pqYmuP3228tykyZNavbJyfnz5wcDgUDY98WkLUT4zjvvDC5ZsiTu+vguEB33+jg/IAbXXnutTO66z4N0hBvHefbs2c6AUF5eHpw4cWLU8+zjjz8WIYMAzpo1K+z8fOGFF5yJ1ttuuy3s83bddVd5/YgjjpDtayBoGND0vnz99ddJTU7q8x0PCPKyZcvkdezrqaeeKq9D9LGfGAQ0X375pWMcXH/99Rm77vR77733nvMe9hmDCt678sorU/6NiEHCPW/ePDlZx4wZE3VdXDjRogFaSri1xQLRaQr6Oxx99NER723YsMERu1deeSUjwo0BAMtoQYJYffjhhy0SFfT666+HWWDeByzFJ598Mub6ECUtHNEeGAggNqncPbiF+4ILLoh4//PPP3fedw8ukydPjitEjzzyiCNien8QzQRBz8/PD65bty5iHQihFtPHH388ZeGGGLv57rvvnPfOOeeciM875ZRT5D0Mnpm67vB44403ItabO3euc2eijRPSvGTFxw0fGSa03nzzzajvw0/njlpoafTnZ8pvF22iFAkmffr0kb8xoZoq/fv3j0iKgV8bftJXXnlFIl0eeugh8UG2BHvttZf4nxFlc95556lhw4ZFJEThOEydOjXq+vAjw7+KeYKrr75aYsu17xusWrVKYuoxN7Bp06aM/AZDhgxRgUAg7DeoqalRL730kvyNaJhoHHXUUeLz/vnnn52JVfyWyB/YsGGD+H+9IKYdPu90zmnEtMMf7T1eGj1p60bnFLiPVVOvO0RswVcf7XjAr45tYx6DGJCA0xQwkYcT//PPP1dLliyRB/5GpIIGk14tDU56nPCZyrbr3bt31Nf1BGo6kSjeBBxEdUCsMck0duxYdeyxx8rF1JJgHzBw4KHFEEL+7LPPSiZnXV2dmjNnjkyinX766VG3AYHC47LLLhPxeOutt0TQkcADYUQW6vTp01Oe2I32GyDsEOcgJgf1b4DJU4g3iBaa6AXn6i677OL8GxOHmMBD5AzO5++//14tWrRIzmud+ZnqOY2IGi+YUNR069Yt4n096EXLnk33usPvFg0Mfhio8VthW/vtt18K344YJdyIy4UFBQvLzaBBg9RJJ53kzKxnA4T4fffddxH7Fg9YlDh5o13osSJNmgKEsF+/fqo1A0HBAIIHYrRxQS9dulSiO2IJt9cCxDp4wApH3DwyJ1Fm4NZbb3Us2GRI9jfYuHGj83cyYYfu5XHHgZR9b6QKopMQnomSBemktWNAjke8zNhMXnfxDAG9j+7jQZqPrLhKkNhy6KGHysmDi/Jf//qXWrhwoSovLxfB1DHU2ULXQkHiTTLWEW6Zd9ppJxESuCnaE3AnDBgwIOFAizR1hLUB/MYahPZtv/326owzzoi7PkLPYK3r0D5Yss2BFiAMwPYcUNyHjuFHeQDUmIFowwUza9YsORdWrlwp5wcSjxB6l02aet3Fc/FowY5m/ZM2YnHjpMZJj1tRXd/CzU8//aSyCeJZcUHCVQJBQh2OeKAAEr4PXAHwA7Yn4NeEFQ1L2FsUywvcOADx0G5wi45Yc8wpxHNNdO/eXW7LIdzebWQK+JPxGdgXiNl2220XUwTh18ZcA9wW99xzj7iGcLf2wQcfRFjJ2N7q1atVNmnqdRfrDhTnPe42gNcXT9qQxY0LHcTKtLvrrrucv7MR2A8f9wUXXCB/X3LJJZKwEM9Fct1118nf8L2mcvveFoD7AiDpKdHE1Lx58+T5gAMOCJs0hFhj8lEfx1igCBNEGxZ6c7mJYNnvueee8jfcMbHcDUjegUghMcZ9TuO1aK4NuHd0Bqv3nNaujmSqOWbzusPvq7fhTS7DnBAqZu66664Z3WfSioRbWzG49XVbIZiR/9Of/hR2AmUjqkQLNqxn+CQR4YB0dkQGuK0M1N/ARBz2Ef7t1lCrpKWB/xqRBhBUVP9D3RHvpC6OISJNcAwxsMHH6o6OuPDCC+VvZObh7sbtSgE4vlgX7yF65tprr5Xn5uKKK64QMUWmI3zrerISwE+NDEY96OhKhfqcfvnllyWLV4MJybvvvjvMFeQ9p/UkNUottObrDmKOshJu8cb3RW0cgPO/OX8X4qK54gzjxQEjgB/xrngfz8guQ9aYzt4aOnSokx32/PPPt3gct2bTpk3B3/zmN04MK7IQsW/INnNn3u25554RGWogUXVAZJ/h/XvvvTfjmZNNJZU4biSbIFlG7xvi0wcNGhQcO3asPCMjEq8j83DhwoVRt4EEFR0/j0efPn2CO++8s5wX+lxBNiKSaJIlmeqAsWKo77jjDifOHkkriH3u16+fs71x48aFVYPEMXC/j2xEnCcdO3aUfyOGG/+OFlOujx3Or9GjRzvnQ6LzPd75FW3dpl53/fv3DxYVFclx2XHHHYMDBw509uHss89OK0mKpEdWLG6Eq6GCH+pFw+8JVwT8azvuuKPUXEbI18EHH+zclmYL3DYjpvfpp58WyxK3ggj1+uKLL2SiCfUgcPsOK6w9T8ogfhx1RmB9IU4bfl40BsBvjFto1GjBJCT8oLFupWGpw+305z//WcLOYN3h35jcg2tER0IkE42SCaZNmyYhc4i0QMw9wuXgw4abAeco3Abuejg4BlgeNcWxvzif4btHGOL//d//yTmD9wBqnbjdIqj1AfcRXEaoL+IOy2tN1x3cQO+++67cWeE6QHjmhAkT1DPPPCNuJVrbLYcP6t2Cn0cIMQwUmUI4J0Q9XoEt0nK0mbKuhBDSXqBwE0KIYVC4CSHEMCjchBBiGJycJIQQw6DFTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxjKz2nGwKqHmM0qoork8ICYFuPOg5iV6apG1irHBDtOvq69XajZVOpTWrOpnP/nfQKjjpxlUq2Id/OB3Srdfi1duSLTYGrU34Ze3Qe65WVno/fD6/8gd81m4478vC9m7Zn2W/7/P7lN/nt17Vy+j9kQ+zPlNvSy9vfQd7a41B1Yj3Xe3WZDm/P7Se/Z1le1jP3YoL38/vV36//nbyia71cINmfQ9rncaIY4zPk+3rw+/6XNlXeznU78YD+ybruI4o1sM+YB20jmtssD4HRwXdabCP1m8W+u3c68pn6mPR0KgasZ/2t7G+n/WZcq40Nrr2L3Ru6O9h/QShL+kcP/u7WMdbDkjEeeA+7/BbOcfGPpewX7Ku3UxB75P7nLLOhejnpeynPoft36yxMSjXBWnbGCvcsLTLq+rV8f98SVVurlB1tXVxl2+or1e1NbUq4A+oguIClZObq/wBvzzn5efJ39HAxQPhiHXxWBekJWju5ZzXsX5j7PVj72+Dqq+rd8Rb9rMgzxLNxkZVV1uraqtrRUDkordFJ5CTo3JycxwRaqjDdupCAughNz9Pvr9eXu93rHr4sh0MDPbXwbbrakNCUbWlQlVuqZR9hIjozVRVVqnqyipVU1mtqiurVW1NjaqvrVcdu5SpDp07yr5huyjniu9ufaeQcMt3aGhUBUUFKq+wQAX8fhXIzVElHUtVYXGhfCa2D7AejpXfH1CbN2xUVRVVqqi0SOXm5anKLRWqrqZOdejUQRWVWmVZ8RnYH719LKc/z4+BwgdDoV411NXLsji+nbp3UUUlRfK5dTivcnJUwD6HIOZ6Weu3y1HFHUpln+pr6+Q8xDHAwJWbmyPrivAGg/Kbe3+noD6HbJHH98Z+Yj098OjfHq8/fOZ+qqzQ2EubJIHxvy4uipKyUsc4jW1p+5yLWltzsQg3mHwqkBNIYk8il5Pt4PMCyawf2lfsGWoz5xfkR76NN/0BFcgpVAVFhQk3J9spjNxOLCByELfCokJVWFIcIeAQVDyqtlSKaGHQxPIaCA9ESw8IOfl58jfEOScvV+XmYcAMqF9/WafK1/7qfCl8F4gO9hfvY2DCYAwLW+4YwqxevwhxYXGRY8V2sd/TAwCAqHXs0lGEEgMfzhXZni2w2Ffsx5aNW0T89fbwOxZ3KFH5GCRkUA+oOgw0GEhtq12+W26OKiottoW/Vr63Pkb4zjKAugZ/PSgBrJeTG1C5+flyouB4Yhv4LO/5Yp2zfutzqrEfdWrLxjrZfkFhoQi5/hz8fnInRNo0xgs3TmpcjBpc7BAUWDYAFxAsI1wkyYCLBxeRvkhhJUHAcmKIt7YItdUjwhbwizUMQdMXqjV2+GKs3+AMFoUlRaqkY0nYd2pJLAFLPCBgP/Eo7dRBLM6N68vVpl83ymCTU2r1XMRXghUMq1e7KCB4+E1wvEo7dXQE27LyfaqmqlrEKa8gX6xpSzzz5TMg5hoc14rNW8SCx2+O7eQX5YuVrV091m8C0QvIgKAHEwhzdUWVbAPfIb+wQIQU+y53CT4lnxnIxQCCOwrrXHILKl6DEMOXjO0VFBYo5Tls2JZY2LW1sp+468PghX3AZ2IQ064YGB/Aa1C4XTXYnrbktasoOmwf1tYxXri94GLo2Llj2uvnaddBkuDil4uywRJoiINcxOIGDVn2sHohEl5BxkABsdK3x3n5ubYvORxcrHoQcAaInEDWL9HG+gb5DgCiBNGHiDqumZJi5/vj2GzZsElt2bhZrEQIHsQYFmQNLMnaOlVS1sG5g7I98ZaQFuTJA8dArOq8RpXXGFRF9vblLgruE5dFDeHOza8VlwzQvweOXUFxoeyPDAh19crv86mGBlsQZe7AEk3xRUe4mCw/Pz4zGKcrvbVco3wPCLVliVuWP/YDxoG2tOX45eaI1Y9lgLxfAVdMXcQ5jnMJz9FgJ5q2T5sTbrdFBKtKW85ecHHg4sWFidtLfZsbej9PRCiRmwQXT7QLKD+QH9XVke5Age+BAQL+U71egb9AJkqziYi1z2e7ZCxxgruhIM+aR8CABuHDcdQuCKwDIJLaNVAovt0GlQeBz8sTwaqpqhERhmBrIYbQ18C3HwWIL/YhL5DnCBh+A+/vgO3geEK0cXeGuyP8hnJ3VVwkz2Jp24Iamqy1gCemvq5WtoN9l3PENfHq7I/fL/sTyK1XlZttH/wW+y4xx3IBATl/MHDU16t1q9fIMZP9LipURcVFqkOn6AJN2i9tVrhlQqhjicdfHcIKDPCrBlUvy+bm4ZFnTzSG3m8tpHonkAiIVU11dcR8AFwUEE8tQnBbQEDd77t95hBACBLcJHho4HqAi8oSZssnjuVEwAM5jgWNY49t4nPqapRYx5hQhYB26tY5Yr/hLoCV7wYDBQZZiGTS2FE+ls/dr/Ly4MLJFfdIKGom+smjXTDwocPHjzsmLfjxoj+0UONuBMfUmbzMyVGFJYUqH8estFiWcws7Ie1GuN1uirjLiQ/UJ4JRU7XZCaWzLO6iJCcmowsjrEZYkQDiVIDteaJX4CLAnYFEWlTXOLfBEMe8Aliw6VnU2F51lIkqWHH6TiK/AEIXLk4S4eD5d36hFRao/+0G27eiPurDIntqYF0Gg6qoQ7Ez6SgTfrCIC/ItF0mtFbkBQceg6Z5shRhrf7P+HfGMSVMt0BDQ2qpqcXVgQfwbgqhdDxocQ3xX7YKwok4s1w2san1X1lDfqOpqKh1BFbF1uV6wHexnqucEli+1fdjJgO/hRBVFwZpHCfnySfujzQq3tppCwmTH5nqWs27hC1Ww0BKh0OKh2Nh0EF9mXoew7UW70GSyLi9XLC3xYUvMryUYTfFVWsKfF2FRQ5QcgfUpsX6jCZHEWWvL1rUcBpqKzYgisTYMQezco4s8YoGfYdOGjapy02aZsMX3QpQJHnqfVi9bqdas+NkRpo5dO0moIAZPCL+1naB8PgY48XXboXnwa2OQqti4RdwN8FXbuy2ii2MJEQxUBpx/45hrax8P+c71DeJ/d8JLg0FVXFYqg4X1+b6kwjqxHQzaegDBYCeDZSAQ9rpY2i6ftvMbNSB6xPL9R8OKzUc8e/j5AaMgJy9zd2Wk9WK0cFs+zzq5MGDZ4qLWvmq8jotEWy35dpSCY3XJ7WhOKAFEu07qG2RdbSljGawT67ZVW9buicNYQhrN4nYmzPL8MSebMnnHIb7y6mrHDQDR0rHK3uVqq2ocoYJAQ7ghNr6i0MLJRL9g23CbuL+f+28c2x5b91JdenZzlg8gfM87oPhg8WLy1iffobHGiubBHsJa9wog3nDizuXfdjx0DO3F9+vQqaOcJxJP3dhoDcBxJyCjb6e4tEQVlbqMBjvBJ+rrUdZHuGMsIOw4R/WEOGl/GC3cuDJxq6tvHSWcyxYETDwiVE0DP+Tm8s3OhBOsLSwv4WglhZEXp76g7CdcKOKX9FwsmICDC8CbwKMzEb0ZjEl/M8/6sSz2VNG+5UREm9QDepIxZew7IPF1V1Q53wm+XbE683Idy9pZRS9fWR3Fp41Ju8TRQ7ESq2IJoh7sC5IMi4yFlVBjWd/REp/0MjiWei4FvzdCDPXvrt/3njf4TqnE5pO2h9HCLVEDjl80aGUNxtA2uCRKy0JCHouYwpRjWc3eCSt9WwxxgchoKwiWeHVFpfiry7p2VsUdiq0EjySFxFq/yrEWtcVuil9T4pzhnrCPp04rh+UdEkR9pxPd8hSfdkmRfO9o70W9A6vB58bPosW67gQZtyBiEHZipl0uF3e6eiKwHgwFiUm3JyF13Hb45wXkd4UDD4INn7+ERdp3iTrBJ5OT0qRtYLRw4+LatL48LIbYezFmCrHq86LEV+daflZcmNpn6wauBMuqSu6ih1WPAaCx0RoAsF2IVyxrXSeIeAcUJIbgNr+lY3r1/mxcv0FtWr9RrGhYr3A/aFH0gl2HyFm+c+tmB98bFr+7lkxSuCYzYy6Cwc+XyPKuEl+6FvR4USNeMLhiWfwGqkOpdbcF33qM3xCDfb0e6HC+2O4nRpaQNincuBA6dY8MGUsGWMqYJNK3sbhI4tUsSVXQw8LlxHLWNUesDL5YlrM1WRYuEBAimSysQ4alju7AgGAlckgiSDB8e+6CRakAwcLA4R0IMHjAWk4EJvaQRSnrIC29CBZzoURjxAI6K6F4rjudaL5zuBAqK0KuFhx7schtF4tEi8A6baKFalnexfKIPfEdqh2i3Vj4jTEAaXecRO4UIp49/mWG74rvkSy6Xk1YUbMU7giI+Rgt3E0C0RsuC0j+bobz3rqo/MrvC/kt3deXTALW1DphiLqYlPcilEgDLGdfrLnKEjqIQjxhgJi4qwUm8rlDZL2+ZnuNpL4vIkHwSBW3pRkL7DMyJcMGkBTESsIHEf5nR9W4a45EA4MlBjEdxy6hi1VVsr6VRJMjKfnIlLUGp1y5S9AuER1OmCzinqmPLDLl/v7YVx1CqaODcM40590maX20uV9aW9JyATQ2ihjAwtWioK0TEYrC5C8qb+0RWMYQkEQTdYkm83RiRtAWoFi307EyNBMBPztC3ByLH/sj1eXsGiEe4YtVUyVd4PuHFer9EBRHSmeCLX6NjsSg+qEW00Sx/jhHUNVPu3gwZkpdGQyEOhrIjsiRAdh2rWCyESKa6t0brHhsJ1b8trhOAtZgDdcTab+0OeGWymnlm1TFpgqxSnCRwf8thYTsiS5YR7GKRsVCfJbuW/AYblKpbWFXi5PPR1o0LDtEsCAl3HMxJxuloVOwJYXcVVZVthtFgDX47lK+VFvqyMAU37H1PqxJXQ4VQEzzCwszpt26qJMbdxZhS2JNSlq+/+TXkf87f/v9kZcMBnO4bzCxCKw0/XzHAvYnKeTiMmlCJAtpP7Q54YZAd+uNR2iGv0HqUdvV+2SSyBdZb1v7C20XQvQoh8jPQxQDhM8bU6uLLEkxfp9VJa4S9ZdhOeejil1qyqjToKUGS2W14/6QyBpEJsRQ2kSp8l7fsru2t/t7OO/HmWSLut+S8NI2U7ch2LgLg2jjjgzNPYCElooj2rqjkIqF9jGQomLV1Xa1wAYrg9NOBtJ3Aji+6VjspP3QZoTbK8AanY6tw+r8jaGLAyAMCxedjs+24okTF5fSwO1QiDKmYcIfSmjRqctO2dcoyS6guqpaVW2ucELQvGCfkJSBgalj7CTFlNH1teOGJboscvf+uH3hsW7x4/ngcUikuYLtSsHgI+VZDYlRtlLZOyQMM9XzEzq9Hi4ROcfsY6MrBeowRklnh1skxvZgJOB30W47PbGebnkGYh5tRrjldrUyshqgTBgVhVwjkkhTWS2Crd8vLi1O+6SH5YtsTSfaAxedRJn4orpC4JooL9/gWOgQP0y4yQRXCkWSrAEBYYDhr1sTlggDVBlBwvlcAq0tcK81KN1rogh3ophqfVcik4R5uVY99HWVYcu0dkEX33djQ1iUCTr0OCnpuma8XYscd1u6A5MmlVhtXV1Q32VhO00pz0DMo80Id6wJG6f7iC0quhiSlB5FmrRdHc6LNdlU68RTS12L/HwRIpQCdbqd2JEd7kqCgWDsuG3Lh9x0AbLafLnEwsa6gK3qdWHhfZ7IkgI7vC/VELJYFnosl0y8yTbBqmhqWZ/S/svKgA3/Upnxietyrpi4tjZrCSiiS3RnGXldN3ywJ4N1FIeuMWKtF6rxojMeUaQKBHL8zrkFINR++NbxZZPZT8+/o5WLZVJO+6bNCHciS1zfVuIi0+nk+nWrf1+4xa39jMGgXRnOLvrkLkrUHER01BGfckB6Ikq1P49QowQriiChYodeD+KE9fRkVyYmvDCIYR+0qiADNJqYan+tJlG4ohfLeozcbrTxxX23kez4g2PkdCWyQ/ow1lkWbGhj7sEc+wMhRq9L+Vz77sLZDuLJi9FlqWmXE7ape1i6kQzKkuKYk6oSSWUX3pL9Y+uyNo/Rwg3Lac3KX1THzmWOFWt1DYHLpC7MZ53KRSXdV1DCM8qFIu/FEQkp4uSqtazRhfoTWY5WfevQ5CPWQZQH6kVHK3YkceF+n6oTX3R48ah40Sap4s/xq9xgXqiNFrrQRCly1GjPIaSDrk2C38+NpMqXItGmMJSIs6XC+Z2xL9JKDeKZZ1nu4du1wvjwm0jER8A6V6xwPmsi2rKOY3WUsQcq5xWrumDoO2OwrIvYbxn886y7iGTAOYomxqki4a1hk5l0m7R1jBZuWMG6CS1uYys2bXGSI6SFmH27Gs2CS7bnpJdE8dv4LKuXYLhlrAUiEfGiQNChPuZ69p2AnuSCiG9ct8HpmFPSoUTagqVb6wRimGqVvERg12ApiiXvqpPdRfesRMIMLH3ULEctmIoq63vatdJRx8PqRWkN0laMdSBm4o2Osw7rUGM3BE5qfxuDEjkSUQnSqTrorvoX+uzmxus6YQZl28do4ZZJK/v2tbHBap+FW1+8BitE+kGiy4sLXYs5luXb1E4zKNsaCFitryAU2vLGZ7onlCLft+Krm1pEyvLpB60OQB3QAchyDVnZmCrj6NZkGmnlFfC7mtzGrjUivm1ERKh8V91vl/Dak3AYhBslldyqySLuLWnIkJeU6wrHNJrLCMcegwEG/PDlo9cmkeruUXpQ6sQZPeGs62wnW9uEkHYl3EBXnfNmFuLiRlsyHb+t8fkRX9v8+6UzNt3RJm5LyB/1/VD5WHcnHim25O17CF8thML+LuILh8h5joOuWhgrjbqpSEU7qdsd+t7Ylw2/rFcb1q4XAbPcGIWS/JSKD9znej96Gn44+K2RKQrrGp+baBLYEujIFH9pNRZlAJVOOq7JZRlEYOU3BFW+exMy4MS+y0PIJzr34G4Iv220728NuM7mova0JO0X433cq5ausLqkoOdgQb7jwtCdbbKF5UvNS2iZR64XsDvXhOK+o5msiGJA/LOerBRfeKAgYllvOJ9bPNC7UTdK0FUMU0Wq+LnCGGEVoy0ZOth06KKrJVrp4e7CSE3BKt8acpFo15jMZ0jHnMKkw+OaEq0CK7t83QbHYsfxszr2WKGLsYqPSTigjjiJEdHk7u4u3d/jdHX3ruedXyFtD6OFG6LWbasennZbVky1T2efGdZw1SvosGatWiO6LneBdRveRJcOsknFUtaTmRCaGMlBqZBqSnk6YJ8RfbGlfLMjfh06l9kusPSqIqYDPg9de7r06Gq9EKe2uJvQZGh0cN66k3osl19N1Elb3cHJ7eIxpWY7aafCbU1m5blactWoio2bxQpCXHVZ1052g9qQJW4aVo2U3FAYXhN7YYa227xhjd763IIdqqiTn3Dzjw447ibB8cAhsDrKNFhd5CVxClEbsQdnb7f2ZJtIJ0tLDBR68jEyWsaeFHUSf6zJcUaVtH2MFm432hcKi6NT9y6hOOgEKd2ZxhGKBE2CkyXTQtPcyNxCfUP04lmYTPaUH43VyaZqS1Vkqr0vvO6HVacFdymeSUTUxa6udiJR4FaxfNPW3UpzZ2BKQ+YaRJ+ERyZhv9PpEi/lXFHcqnlvZIhBtBnh1kiWWgab7qYKLljxM9oRBhJPHaVJcNTON7JeuH/S6oBT6Aw+Tvd1lw/caqgQfbs62UiPI+gg35zp0bq8KVwvEhGSRjlaq2UZJjO9vvlQq7MEGxCBxLGBVS6JNvakqVdgcdydhBc9MNjHR4d2ppVYY08oRr5ISNNpc8KdabxNgnWJ2FhCnGwz3sj1rPjkiHRnj1BhQhHCqG+Ppda4WHDRRQHuI3fGJeKWdVicFXGju6iEV010f38Im96vPKluGPv7eVP64YtGpIf9bZwIk+a809BhhoksW3xnb3EmnVgk5QSC1nwJBB5uimSr9Ul8eAu4oUj7pd0INyxhtL3yFj3SyRyxrCpc1IjKCJV9jS5wTSXZkC+JnkhhUjJW8Sq4EUTQbUm2ok9QuyR6Bx+Er6E4l2Qm5qJwV/yiWFY1PBxrxJAjyUULvi9xpx5Yvr7kCyfhp4FbwpsYI5Z2buzOOrEEXuqpV9fIoCWT3Y1WISyWWSWthTYj3FaqebWT8QiXAixFqTMhyRr5kj0Y7eKLZ9ml6yOXKAAUo7LFBFYorM1k05+bm1hhgrHmDnD83M1+E7Xk8gqdrvUSs1lwZZWUttXrSgu1woKIybfogm4VefLW+IBFne/LT/mY4/e2ytY2bzipLk6l3WO6NZlpkVCk5Wkzwi1V5USgQ7U06vIti0/qG9thU6nefutb5fCojvBmA9HArXJ4uF6K3cpbGCuTE8Ln6pTj2n8rTDF5QUnFt43jIi4Uu5ckjjms+/K1GyQUEnVJdP1vVICE3zpaBm0qZXFbstGCdVxD8dj6uCIBx109Ece3pSfTiZm0GeF2Zt5dwMp1urmjXnIw9a+ru7RryxmhebAGk7HiMhkNIg0NpFGtdaHDT1zcsSRjF7lVKU+nqqe+7/Bl4w5Dg3ouqXQuj6z3HRB3DFwd+J7W5CImO81JI4cLBvVh3BMX7sMKoWarMtIuhdtpDmxPHuICx+SguzmwFHhK0+JNt0lvrF6UEcWnYL3L/sUHvuWigFVUCW4YVIPLZJSCN/UcIrzp141WjQ9EZiRYX4S6OCTU6RxrsbSraiI64iTqMJMtQvW9rXMPcx+B3NywO5Mm9jaOzJZFExBtoaMuT1EBu7u3Q4wXbh3qFdYNJKwmiF/l22U8WwIID26PpV1aQ6O4TApLi2SCy2rMEB7uJ7fGEt+bK40adCcZvKbbWjnL2dmg6ViyqeJ2XURDJjeTaGmWchhghuqHtwS64JXTckx+ywDKODbL5+E8x/F1Jso5YdpuMV64vTVBEMmwecMmOxY4cX2HdJoGx0OHw1ld3qsltAzWK/ya8M96J0d1T0p53ac729SrHPw0mTWqMwruaqJF4rSnyAtrEhODVEFazT10Rqm2nBOdq7plGdZzN1zQA7p3XoK0XYwXbi/wQXfML4t4XXdH19ls3qbAuoFB6P28qJ1xkiXZWiLecLSmumbgj8dFrS17WK86CSWTZHsSDUWy3O3Y9J2WtzUZXBe632hrAfuKeRKcY6hFLkKODM/aOmtATKLuuTu/RzdSkLLBrFPSLmhzwh0Lq/1TUYRFna5g6gxBr+sDMc7JdLqJ1U1db093sEl1OxJGl4KrwZkMtF028UinVVhzYDVYqAlrjCBhdIGAiLluHoEdRsq7FnJkReIuLF1XTubde9Zgo+dn5Ddw9S6NhZyrnXXlRdIeaTfCrW8z0wUJItJhxRYFPEuBI0+uY7x45XjoRgvu1PSWsGjhWkL8dL7dIs29626hRjq+O2oEAoiBMBt4feG6ww0aOOvyrpkEA1tVZZWVJ1CLQSDolG7FQJ3ueZVqE+FY6J6TyPYE7DnZ9mk3wt1UoYbVBpFzd7TJh6slQz5dud2N05qsufCmqAddlmrVlgq9dyLUXXra5UtbGVJsCinmKaaZ47eEiwJROnrQReNlb8kCaQaM1/PzxK+MOQgMqjInkpO4vjiWw2e447VxRxUrW1fmOZC1aSfmWL0rw6NVwvfP6lYfSopqpRMjJGO0eeEW3zaayrp926hQl8CPCKGGheXEb+flqqIOxWHx29FKhmJ5fKbT2QaFlnLR99KMiwnHCpa1tf92bZGSojYpBTK5iAYcOnFHikz5YzcLtqN/UgXnhTsj0gp7ROXCRlcIq0vI0dzY2yItTgMKXepXu1lac6IXyQxtRrityUcrQSVMoHXvRaeYEuK5k/QjxrlI4ZOWpsIN1udJ2F+x5UPHrapumeZv9NudF1sn0gnH1QINAxriptHVvTnS8xEu6fimbUs5m70ZIaZBX9CqS2JbxLoqYKZquENU3eeSleoecO7e/BHlAXS0SiThJYNtY6GhQY6rNk687fpI26PNCDduFYs7BML69FmTP7CWImVTapnYlf9QvQ7rifsDNUVQhjXBRRuvCqD7FhjCKJ3n4QpxtSFLqjxpC4AYZEl48VzrsAADRZkXbkQ/5OloCNW0eYeMEfTcPXnupDKNFnKcg7UYyOwBAz1DY/WgdFqTIQywNrKlWU6H0DpMmW/7tBnh1kKdNFLRNCihYrDIdTo10r5T2o4Hy1WCRBvrwsddQMXGLVYiUGEoSkQPENrS0nHfOsQN/lT40Ju7DRWEoiVLkOJ4e8PzoJGY/EShKUEmH5se/YHt4m5CR23EqssNIU3HR95U4NoQ37V9PKTyZJw5E2lp1ql1ZpGSlsV44ZY7R7GOIipZW0WlYqwnFrDUWLYuGgiqxME20QrGJBRSxXU2HWKoe/XrnTAtGb7l9T+vVXW2q6djlzLVJR9hhen9RLDO3HW0JUEjL69V+j+lyJRdDdB5LRMDlt1UGIOitU0Mnvlxmzi3JF4XCiHtRrghkJK84KmzjQvCXWcbt5e4zZQIATuMDL7WkDVmWTta6mVSMR/NZ1OzvkWAXJai1EhJQoSQVYn9bQxaZUxlX/zojI7Gx61QbTOMzD1EcWmlgtTlbqhXjfWhut650oEoMyn03o45UgirMJ/iS1oc44U70SSiFmwRdhFBhHE1OJa1NAWww+GwrJNQk6aG6M4tVn3oOsf1Ad+utNOKIcIQajzE5+5KxLH6JIZal6VbNKp9EJTJaW1h41jnFUT2pIyHuLi8/m1X93b3pGW6uQG6xom7Dje2Q980SZY2f2XDhwi/YGjeycoUDGsmbKdLZ3KizKpGKFd86N8p1jqRcMS6erWlfLMklsCV0B6s70TgLgTdjFApD+CYaJ94tAYRTocct6/b0x0ego1lcPeGOzGr5nqocBm2H6s+S6rNg50+oPocxKSkL5/CTZKmzQu3VVbTXdLVamWFi6mhzpq4wkOSHNB0N0PCmKjnYaiJr6vSm8uqln1BBxZ7wLGKUCW/bxCf6qoaRxxkErIwP6uRLHoS0ulBaU9CploNEL+Ru4ys/o3jfbD2+Yd83Zio9IdlRiLCQw/22CdE1mQKdxSR347tj3V+YH/cpYo1gTS7xJO2R5sX7lhIh5za0MWha10EbLsYFw5cLE4qNS5mhF7lW1ZXUwUQIoLsRMclYvtipQUbqgp6aqBAROA28X5uRIceuwYLXECFroEgnUqHzTMJ6RXqdBsCJ19fHcckXqs2DIrFpcXySAdtUevMSEnUyUdxqxzn2Kc0CPjs3zHoiX5BtFNrnF0mLU67Fe5EPmCE40GsnWJSDY0i8r66eqtAUJITadGEFRafdHWPcjHLAOIqhpVIeL3FqRyfuO0zTxZdXlYDq645fOTWV8iO+OD3Q8nfys0VoW7sRQVWyzt7QE4PO3PRPt7wreO/RK3LYsEu8SQR7Va4k0FPRjUlZEun3OMZwghLDHUvnIs8EIjaMCHdWiPpYiUk1TpzAXm+5ITM6uYeatLbmmtCw2KVUr06IxQp7rofaQqWLAZxFOZyR5dgu9FcPiUdOyjVMZTqGO9jcH6462zripZw3YRNmvpaxx0UyR5tTrh1BxknndguMp+tGXtdl1ua8SKuGpZ7fYNTAyUnzyqkn+o1iGQdWHM6agXV6gpLitNO2Em2frgXiX93pcanepylrKz9HazQSQxczSNI2C6OE+504I6SXqT4PfwNMpAm6zsWH3lBKAzQ6kQTaPIdhpNgY+szop8g4hBzuatqaLQzdq1Bov1FDRFN2+k5aQuhRcjNINEDrWAyJ1O9K93bg0/W7VGBSwcXczoDQbo0JewQ+x7ZY9JyXURfPigDFtbRQiyujhQnEWF55yH+2jVQxRLe6Ovbk88qEDtjE/1F9YCk+54m8aO4dR53QVs2bXFaxOF7FncsbXXd7EnL0yZ7TrotbIg6wul0fQdYlchmzJS14m0CbE0OYn8SNWCwls/NQ8sphIL50rqz8PrCQ2GNzaPc+Ey3L7wpwq0zJpONKtHlW90DYDqt0kR4pTdkEi4RRJt4XCKJ7kwaG9HRplpcTwC/Byz9VAdufE7XXt1SWoe0D9pMz0mr9ViVqtlkVZ+zJp5wO2mF5VmTgaHu75lCf66OTsHFhosUZUCjoWOI/TqGVwad7FvwuhOOJlZHHD1gtGSPSQxOmFBEFI7eN/h+E2VEeruw6/KqKblEbNeKXh+vJQLnWHEHRKikF6VCSJsXbg0uRitJIt8SlqCVJaktcSQ/oIZIY5hLxUqJlgmgNK1GTDbikcp+ZsJ1g24nSPfH94GYWlEguc73xXdPpclDnS5yZRvwBUX5Ilq+OL5wbetHK1uLSAoMoLpzDDrYY+BMpws8vhMKgeGRKhiMnDA9O/Ijlosj8nOt2Onm6tpOiGrvwq1dBGJdu25ldZ1uJNtg8gtiZDVSyL7fuynAf4r4cogiBBcDDwYtLdy6Z2WykQfwK8fyLbvRYZGIccekGYRNOsd4WpmJyyo/V5XkBFRRieWakuiZFs789E46ags8k/W20wUlf6Vejqusa7LNgkn7ps2cIbgYUZkvfJLSspgwmeMvCdWXSCQeltWZXAhXttB9BrGvEFwJR2tCVEmywG+LgQLAN60/uzXWSsGdyJaNm1XFpi1hHW8KCgubpd425i1wF6TPQavlGFLrAwk644TukpJpFhy19gna7DkNFNhIoa1jvHDjZJW0dVwscI/oIv22q8CKKgldHInQGZP69hoWECzGbFtnXuJlAjYnyVrmzUX4oOoCP7y0BKtxJgUhjPjtOnTqmFL8s5MCb3fqgfBC8BOHS6KMgeWagYDj3JRELmRRSs/I8HNIXDcyT9H0ZsHSyNg+Z9kBp+1jvHBbbZtCJ60mJy+5ug7epsC4te7QuWPMi1saHlR4JiOL0TQ4OWGXeG6JKtFNhxGXm3pUSWvBSiwKldSFnz2VSVOrlHpkNb5odzq6uJQOj9PASoWrBgOKO5lJ3GeYnE5xQhoTy2H1waWOTOLfRybECwskzFCaCtc1OOdYMzbUse9uQv5/Vhls+xgv3N6TNlUg2rj1d9csQciZjuv1thiTNlE5OeE9LFNIOpFOO/l5oWbCKUaVaB+zFfWRXkRKJkCEh5URajUqkOp8iPIIplh0SpJL7KJTGrGUUe0vPGoELq5ENUWScdFASDF4hhedciXU2K/hN0Y54FR7UWoBz89MGXBC2p5wNxVc5CUdQ8IPEYJPVPspYVHDmnPXYG5KwX9x3zShAwvqfOMOA9XlkHySrbofEs/sSnyR+hwpjiISx11iTRa7X2vuVG5s3u1bFos6ilVu3Qw0vRelTEK67gp1A4aEA4wUQrNKJUidHDSGyMO5g4EnlHSG7RQUo/dku7+c2w38pTOU+p0ICY1zuVh0V/hU46Cba//SS3xqescabbnrbYqQeyztTKMnBVUC4fSn2IsSQltTjcSbUPih5brxy3eV6pN25FPyv7vlyoPwSxXC3DqnqTXuACQJS6oTohBavcoRYSdtnXYj3N7WZZmKeNCd4pEtB2ARWa6W8AtTysHiVtzpQp9cS7PWitRbaWgQV08010GYperqDOQG/yzyhBGajNVDEkleOU7TDiv8MJRBmUq0jW4wjQdqmEiX9woUoapzMoHxGfowQ9CLMpxgRlonxgu31K92xcKKj7qwIEJMMGlWUtbBcixkUjClIUIo61DXp/ASTbgS3V5LxxRXI4VoNUh0Q4aWHggsl02NDFLRhBvzBhAZgPh5mexLs/cjvqPlC4/seNOaCFnyodcy6eeWIlRlHSJcKfouTsfUk7aP8cIt/sKCfNVoTyzFKouKyAd3mJ+UV3U1E27K58OaDtiCLckTGfDRIiPSXdNErLUcy8+pPxdCrl0w4osvLrLvAJABGXQ1YMh85xvpqBPHhZBKDZJEWC4Ud4p7ZMSJFbnhqdui65/H+O5Y3or+CJ98zHb8ebJYFnnmuvQQczDjDI2DxML6I7+GtCazJ28gcN7ek5maBMtUCnuiVHrcHsN/qpMsZLDIQVSJVVYV4rO5fJM0JZY4a/uruQtwmYglyPouxgrL834fLIN2aLpqoEa7xeKKm+tOSJ6a4Vg5HXLsnpPSEcf+/ZJBXCSo023Hp0t3I3RjymCtGmIWxgt3/IulVtWhNjfqedgXf16eFSXitap0eVjt8kBxKohja4mJjVUTxUojD1m2cscBQVfZATVU4OLBnUdTBzSrjKtV68SxvO1sTTcQc1R8xCMVsD2Z6G2myV4YCRh0pKN7o04Q84k7DbXUMehK3HeCaBCJfCordSfzGj0Yk6bTZoUbwpFTqieJIkufRiBZdXhdC7XP6gbfGB6vner1opvUapcHLkJrQMjMhZdqi7KmIjVK4Lu2D6k07XVNLkK0EarmK7DuRpqClfnYeiYvdbVBPbjDDYPzLNbxt3IEQmVhceeH7kdIgxe/tB1p4gVCjw479fYEpAZ3U0gKMsWVQ5qPdnEGJGOdSHREYegiwq0tiijJBKGrXCsseUyS4aIEEppVhMzJ2GVckYnXWF8nAl5b41O5tbUSfZBJAW8pCrzlVD3HNpHv22SkJkh9fSjcD4Omq/ytWNiu2uwwBnAXEK2qIQQfg0DFxs2OsOuelFa4X6jut5VGb2X3Yg4D52A2uzqR7NMuhDseejLPW5wKPnHUVPamS/saLb+pkyKfoNWW1OveAqurRtXX1jsuG2T/leaWSdMFk7Cy0VvPYGN1mrFK+Db3IChFqqQsbbwGClWhKCfp6FMoA5kIrWdwt1wgoSgR96G1qlda54bU4kGUUZ1Vwte5q3FNVKfiMyfm02aFWzc4sNphWRaitDjTqe058GHni+XjgxA3Rpv09Cc9GRoLTIyhTZY3FVxfdDL55rbSnM/xi6XeeiSy9YFjpntHikBmOMJCytdurpRJYS2QKFoV63OsBgolcgdWtblCBBxGASYVrc49eRECnswYiO26I3SkmQWMADt3gI2D2x9tVrh1YwWACwVWGdwZ7hZnElkCP2UUIbaSHawGrW6sutfJT1oi0gETUdqih4+ysBSWvLU+/JjSCNYT/+3U0zbsdhhuJF0ESlqNoYphYUF4yzOfPQfRRF+tDhN0+9gzCQQTk4IlqjSl9fw+n0wk67h6jMlW2nqjymvME1dIsj0oo24fUSkFzJBsz7RZ4Q71XrT/HfCpvEBsi6zevv3UvmtvL0lnO35f3HoVUj3Q5QPHLWzHzmURt8mwxCo3Vzp3ABqINay6TE04eluSJWpN1lTwfd2CrD/D6kSjJ9ui3820FfCd3Wn7MtlYaVneGNTwnE4PSkLavHBrILJauOJZOSgNCiuw0RYUaz1MCIUvlyguGsWfAqUBV/Ngf1SrWacyS5nXmlon4xK+9Xjbx+23tBizl8ctuPS4jOHfxSQrxMI72FgNEAoz7q6OFeUCC9EUK1G7SBDZAWAAxHORJALrN6UHpeMawSDv+r0wPxLNd07aPkYLt3Q4Kd9stSKLcdttWTshX3esCRzddLipQEADKUw4SpeU3Bwn7FAmQ+OIqfhJUVbWNTkaL9UdYsPsujRdJIidbgVg8N24foO4WyTqxI42kUb1OVbylYQdolRtrVVJ0PBLmyTA6F8XJ+zKH35SWw3oE1bDIbJsa+u4ADOReSmRE4ZFopCmgYG3e5+eMd/HII62dbiz3LDmV8dNR9ouRgu3dOG2y2YS0l7RJXZxh2DV36HvvK1jtHDDbTBwh+2yvRuEtApkwjk//WgVYg40VQkhxDAo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMg8JNCCGGQeEmhBDDoHATQohhULgJIcQwKNyEEGIYFG5CCDEMCjchhBgGhZsQQgyDwk0IIYZB4SaEEMOgcBNCiGFQuAkhxDAo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMg8JNCCGGQeEmhBDDoHATQohhULgJIcQwKNyEEGIYFG5CCDEMCjchhBgGhZsQQgyDwk0IIYZB4SaEEMOgcBNCiGFQuAkhxDAo3IQQYhgUbkJIq2HTpk3qoosuUttuu63Ky8tTPXr0UEcffbT65JNPMrL91atXq7KyMnXIIYfEXa62tlbNnDlTDR06VBUUFKiuXbuqgw46SL366quqNUDhJoS0CjZv3qz23HNPdf3114vAjhgxQl5/4okn1Lhx49TTTz/dpO1XV1er448/Xm3cuDHucvX19Wry5MnqkksuUYsXLxbxLioqUi+88IKaOHGiuu2221S2oXATQloF06ZNU5999pmI948//qg+/PBDtWrVKnXZZZepuro6dcIJJ6hffvklrW2Xl5erQw89VL3++usJl73iiivUSy+9JIIN4f7444/V8uXL1b/+9S95//zzz1eff/65yiYUbkJI1lmyZImaO3euys/PV4888oi4JkAgEFBXX321Ovjgg9WWLVvUzTffnPK233jjDTVq1Cj18ssvJ1wW1ri2qO+//37Vr18/+dvn86mpU6eqM888UzU0NIgbJZtQuAkhWeehhx5SjY2Nav/991e9e/eOeP+MM86Q58ceeyyl7U6fPl3ttddeaunSpWr33XeXf8fjqaeeEj873DRjxoyJuR/PPvusqqqqUtmCwk0IyTrvvPOOPI8fPz7q+/p1CPCKFStS2i4mI2+88Ub1v//9T3Xv3r1J+zF8+HBVWlqqKisr1UcffaSyBYWbENIqXCUA0STR6NKliyopKQlbNhn+9Kc/qe+//1793//9n/L7/U3eD7hMttlmm7Bls0FO1j6ZEEJs1qxZI8/atx2Nzp07i5973bp1SR+33/3udxnfDwwiIJX9yDQUbkKI+HN//vnntI4ExC6eCyIZ1wZcDwAx07EoLCyU56pm9C23lv1IBIWbECKivXLlKqVyi1I7GnWVyu/3NfkIInoEk5NwRcQiGAzKsz8Jl0e66G1nez8SQeEmhFjkFqmC4aekdDSqF92jenUvS2nCMBrFxcUSa40kmZifZb9XaFu8zYH2o2d7PxLByUlCSAhYmqk8MoT2Ka9fvz7mMvq9bt26Ndsv1lr2IxEUbkKIDcTYn9oD62SAIUOGyPOyZcuivo+JwIqKCvl70KBBzfaLJdoPuEmQ1dnc+5EICjchJOsW99ixY8PiqL0sXLhQnpHJ2LNnz2b7xRLtxxdffCE1VTB5ueOOO6psQeEmhIRI2eLODEceeaQ8P//881Jgysvs2bPlGfVKmpNJkyZJVULUSYlWkVDXK0HFwniRJ80NhZsQknWLGy6Ko446SkLsDjvsMCkuBVAX5PLLLxdBR8biOeecE7Yeik9988038khU9S8ZOnbsqM4991z5+5hjjlHffvtt2OBxxx13qJycHHXhhReqbMKoEkJIiAxa0amC4k6ouvf++++rAQMGqGHDhqmVK1dKRUCI5eOPPx4xIbhy5UrHL33vvfeqk08+ucn7ceWVV4prBg/sww477CATkj/99JO8D/FG6ns2ocVNCLHwpWFxZ87olqYJEG00UujTp49atGiRNDSA++LNN9+UAlQtQXFxsTRM+Nvf/qYGDx6svv76awlVnDBhglqwYIE67bTTVLbxBXU0uWHghy2vqlcnzWkdHSkIaS3cf/oEVVaYk1JsNa6nlWs3qYLRZ6f0WdUf3aZ6d+vQ5Dhukhq0uAkhxDDo4yaEhMjghCNpPijchJBWMTlJkofCTQgJQYvbCCjchJAQtLiNgMJNCAmvVZIS9IlnAwo3ISREBmprk+aHwk0IcSXgpGhxU+ezAoWbEBKCk5NGQOEmhITg5KQRULgJISFocRsBo+0JIcQwaHETQmwYDmgKFG5CSAi6SoyAwk0ICcHJSSOgcBNCQtDiNgIKNyEkBC1uI6BwE0LCW5elAjMnswKFmxBiw6gSU6BwE0JC0FViBBRuQkgITk4aATMnCSHEMGhxE0JC0FViBBRuQkgIukqMgMJNCAlBi9sIKNyEEFc4YKqB2QzkzgYUbkKIg4+uEiOgcBNCBGh2qsJNnc8OFG5CSAh6PoyAwk0IcaCrxAwo3IQQBwq3GVC4CSEOFG4zYMo7IYQYBi1uQogDLW4zoHATQkIwqsQIKNyEEAda3GZA4SaEOFC4zYDCTQixSCNzkq6V7EDhJoTY+NKwuOkUzwYUbkJICOqwEVC4CSGOZqdcZIrHLitQuAkhDpycNANmThJCiGHQ4iaEONDiNgMKNyEkBJ3WRkDhJoQ40OI2Awo3IcSBwm0GFG5CiAUzJ42Bwk0IcaDFbQYUbkJICE5OGgGFmxDiQIvbDJiAQwgJKzKVyiPTJvqmTZvURRddpLbddluVl5enevTooY4++mj1ySefpL3NV155Rf3mN79RHTt2VEVFRWrEiBFq1qxZqq6uLuY6Q4YMifu9e/bsqbIJLW5CSKuoVbJ582a15557qs8++0wVFhaKwP7000/qiSeeUM8884yaN2+eOuyww1La5gMPPKBOOukk+btfv34i3l988YW68MIL1bPPPiuinp+fH7ZOdXW1Wrx4sQoEAmqXXXaJut0uXbqobELhJoS0CqZNmyaiDfF+8sknVdeuXVVDQ4O66qqr1IwZM9QJJ5yglixZIlZ4Mnz11VfqtNNOEwF+8MEH1XHHHSevf/PNN+rggw9Wb731lrrsssvU9ddfH7bel19+KZ+7/fbbyzKtEbpKCCEhfCk+MgQEee7cuWL9PvLIIyLaAKJ79dVXi9Bu2bJF3XzzzUlv87rrrhN3yPTp0x3RBhBkfBa47bbb1IYNG8LW+/zzz+V5+PDhqrVC4SaEOKTu484MDz30kGpsbFT777+/6t27d8T7Z5xxhjw/9thjSW0P7g64VsApp5wS8f7OO++sRo0apaqqqtT8+fPD3oMrBQwbNky1VijchJCsC/c777wjz+PHj4/6vn596dKlasWKFQm3h8lMiDcmI0eOHBl3m2+88YZxFjd93ISQrIcDwlUCEE0SazKwpKRE3CVLlixRffr0SWp7/fv3V35/dPu0b9++Yct6Le6tttpK3XjjjerNN9+UaBcsf+SRR4rbJttQuAkhWU95X7NmjTxr33Y0OnfuLMK9bt26jGxPR4a4t/fzzz8768Jtg89zc++996pDDjlEPfroozKQZAu6SgghTZqcXL16tVjAsR7JUFlZKc8FBQUxl0GIIKiqqmq27WlrG4wZM0asbWxr7dq1as6cOaqsrEw999xz6sQTT1TZhBY3ISTrrhJEj2ByMt7nB4NBefbHcH240cukur3u3bur8847T8IBEcGC/dIij9BC+L1322039dRTT4mo77HHHiobULgJIU0S7l69eiU1YRiP4uJiVV5eLhOKsdDvFdqWcjy0GyPV7WEiM17IIRJyJk6cqF5++WVJCsqWcNNVQghxgG6n8sgU2he9fv36mMvo97p169bi23Oz4447yvOyZctUtqBwE0KyHg6I2iDxxBATiBUVFfL3oEGDkt7e8uXLYy6jP8u7PbhQamtrE7pYUEslW1C4CSFZZ+zYsWHx3F4WLlzo1BvpmUSBp6FDh4r7BWF8SGGPt81dd93VeQ21UHJzc9U555wTc9uffvpp2OCQDSjchBBXkakUHxk6doiPBs8//7xEqXiZPXu2PKNeSTIgmgRhewDRIF4++OADSdIpLS1Vhx56qPM6Jh8xMQn/NXzu0UT7v//9r9xtHHXUUSpbULgJIVkv6wrrFUKI0DxYvatWrZLXIaKXX365CDpE1msJ19XVSdEoPDZu3Bj23iWXXCJRIbfeequ66667nNex7JQpU+Tvs846S0L8NGeeeaZ8zi+//KKOPfZYievWvPfee2ry5MkS/XL66afT4iaEtO/JSV3wabvttlPvv/++GjBggBo9erTULUFlwJycHPX4449HTCSuXLlSBBQPhOi5QVnYG264wRFaZD7utNNOYlX/8MMPap999pECVm6QLYl6KEiVR+QI1sF2sF+IKEGZWWRO3nLLLSqb0OImhFj4ENPsS+mRyQqBKNcK0UYjBSTuLFq0SCYJJ02aJDHTyGRMlfPPP18EeL/99hOLHKVeBw4cKKViFyxYIP5sLwceeKCUl506daoI+bfffisJOCg3e99990lRKm8N75bGF9RTpIaBH7a8ql6dNOfVbO8KIa2K+0+foMoKc1KKrcb19MumGrXdOQ+n9Fnf3fpb1aNDfpPjuElqMAGHEOLAnpNmQOEmhDhkKeOdpAiFmxDiQIvbDCjchJBW0SyYJA+jSgghxDBocRNCHOjjNgMKNyHEgT5uM6BwE0Is0smGpJM7K1C4CSEOtLjNgMJNCHGgj9sMKNyEEAda3GZA4SaEONDiNgMKNyHEgRa3GVC4CSEOtLjNgMJNCBF8dgecVNchLQ9T3gkhxDBocRNCHOgqMQMKNyHElTmZouuDnpKsQOEmhDjQ4jYDCjchxIHhgGZA4SaEOFC4zYDCTQhxoKvEDCjchBAHWtxmQOEmhDjQ4jYDCjchRGCzYHOgcBNCHGhxmwFT3gkhxDBocRNCLHxK+Zk5aQQUbkKIA10lZkDhJoQ4MBzQDCjchBAHP4tGGQGFmxDiQIvbDCjchBBXHHdqB4MGenagcBNC3M3LUjwalO5sQOEmhDjQx20GFG5CiAN93GbAzElCCDEMWtyEEAcm4JgBhZsQYsGUd2OgcBNCHGhxmwGFmxAisB63OVC4CSEOtLjNgMJNCHFIuawryQoUbkKIA2XbDCjchBAHJuCYAYWbEOLAlHczoHATQhxocZsBU94JIcQwaHETQgTW4zYHCjchxIGuEjOgcBNCXLVKUjwYjB/MChRuQogDLW4z4OQkISTcz53CI9Ns2rRJXXTRRWrbbbdVeXl5qkePHuroo49Wn3zySdrbfOWVV9RvfvMb1bFjR1VUVKRGjBihZs2aperq6mKuU1tbq2bOnKmGDh2qCgoKVNeuXdVBBx2kXn31VdUaoHATQkKC4POl9MgkmzdvVnvuuae6/vrr1erVq0VgwRNPPKHGjRunnn766ZS3+cADD4hoQ7w7d+6stttuO/Xll1+qCy+8UE2YMEHV1NRErFNfX68mT56sLrnkErV48WIRbwj+Cy+8oCZOnKhuu+02lW0o3IQQB2hxKo9MMm3aNPXZZ5+JeP/444/qww8/VKtWrVKXXXaZWMcnnHCC+uWXX5Le3ldffaVOO+00FQgE1COPPKKWLl2qPv30UxHuAQMGqLfeeku27eWKK65QL730kgg2hPvjjz9Wy5cvV//617/k/fPPP199/vnnKptQuAkhoR7vvhQfGXKYLFmyRM2dO1fl5+eLyMI1ASC6V199tTr44IPVli1b1M0335z0Nq+77joR/OnTp6vjjjvOeX377beXzwKwnjds2OC8t3HjRseivv/++1W/fv2sY+PzqalTp6ozzzxTNTQ0iBslm1C4CSFZt7gfeugh1djYqPbff3/Vu3fviPfPOOMMeX7ssceS2l51dbWaN2+e/H3KKadEvL/zzjurUaNGqaqqKjV//nzn9aeeekr87HDTjBkzJuZ+PPvss7JutqBwE0KyzjvvvCPP48ePj/q+fh3ujhUrViTcHiYzId7wTY8cOTLuNt94442k92P48OGqtLRUVVZWqo8++khlCwo3ISTrk5NwlQBEk0SjS5cuqqSkJGzZeOhl+vfvr/z+6DLXt2/fsGWT2Q+4TLbZZpuI9VoaCjchJOuukjVr1siz9m1HA1EhYN26dRnZHgYD7/bSXa+lYQIOIaRJCTgI3evTp0/M95NxbcD1ABAzHYvCwkJ5rkrCt5zu9jK9H80FhZsQkvVbcESPYHIy3sARDAbl2R/D9eFGL5Pq9tJdr6WhcBNCLHxpWNw+pXr16pWUVR2P4uJiVV5eLhOKsdDvFdoWbzy0PzzV7aW7XktDHzchRIBko8hUKo9Mubm1T3n9+vUxl9HvdevWrdm2l+n9aC4o3ISQkCCkKNyZYsiQIfK8bNmyqO9jIrCiokL+HjRoUNLbQ8ZjLPRnubeXaD/gJkFWZ7L70VxQuAkhDqlmTmaKsWPHhsVRe1m4cKE8I5OxZ8+eCbeHdHW4X5BMgxT3eNvcddddk96PL774QmqqYPJyxx13VNmCwk0IybrFfeSRR8rz888/L1EqXmbPni3PqFeSDBDWQw45RP6eM2dOxPsffPCBJOkgmebQQw91Xp80aZJUJUSdlGgVCXW9ElQsjBd50txQuAkhWY/jhoviqKOOkhC7ww47TIpLAdQFufzyy0XQIbLnnHNO2HqoRfLNN9/IA3VG3KC6H6JVbr31VnXXXXc5r2PZKVOmyN9nnXWWKisrc95D6ddzzz1X/j7mmGPUt99+GzZ43HHHHSonJ0eqC2YTCjchpFWA4k4ou/r+++9L9b7Ro0dL3ZIZM2aIWD7++OMRE4IrV64U0ccDdUbcoN7IDTfcIGGGp59+umRK7rTTTpK2/sMPP6h99tlHClh5ufLKKyXlHZmRw4YNk3WQLYk6JfBxQ7yxjWxC4SaEtIp63GiaANFGIwUk9CxatEgaGsB98eabb0oBqlQ5//zz1csvv6z2228/schR6nXgwIHqqquuUgsWLFC5ubkR68A3joYJf/vb39TgwYPV119/LaGKqN+NdVAqNtv4gjqa3DDww5ZX1auT5rSOjhSEtBbuP32CKivMSSm2GtfTpup6dfYDoYJLyXDbiXuqDgWpfRZpOkzAIYQ4ZLo5AmkeKNyEEIdMuz9I80DhJoRYpBMpQp3PChRuQohDJmOzSfNB4SaEuGqVpKbc1PnsQOEmhDjQxW0GFG5CiANdJWZA4SaEOPjo/DACZk4SQohh0OImhDjQVWIGFG5CiAOF2wwo3IQQx7+danME+sSzA4WbEOJAi9sMKNyEEAumvBsDhZsQ4sAiU2ZA4SaEONBVYgYUbkKIA1PezYDCTQgJFZlKMXOSRaayAzMnCSHEMGhxE0Ic6CoxAwo3IcSBk5NmQOEmhDgwHNAMKNyEEAe6SsyAwk0IEdi6zBwo3IQQC6a8GwOFmxDiwPhgM6BwE0IcUi3rSrIDhZsQ4kDZNgMKNyHEgeGAZkCXFiGEGAYtbkKIA10lZkDhJoQ4cG7SDCjchBDH2k69WTDJBhRuQogDJ73MgMJNCHFgHLcZULgJIQ50fZgBhZsQYuNLw+Km1GcDCjchxIE+bjOgcBNCHOjjNgMOsIQQYhi0uAkhoTjuFI8FPdzZgcJNCHFg5qQZULgJIQ5+2tBGQOEmhDjQ4jYDCjchxMFHi9sIKNyEEAs2CzYGCjchxIE+bjOgcBNCXGVdUzsYDAfMDhRuQogDJyfNgMJNCHHg5KQZMOWdEEIMgxY3IcTBT6e1EdDiJoSEuUpS+a81EAwG1Z133qlGjRqlCgsLVVlZmdprr73Uk08+mfY2Fy9erH73u9+pnj17qvz8fNWvXz917rnnqjVr1sRcZ/r06VJdMd7jm2++UZmAFjchxOjJydNOO03dc889IozDhw9XVVVV6o033pDHBRdcoK6//vqUtvfFF1+oPfbYQ23cuFF17dpV7bDDDiK4t956q3r88cfV22+/rQYMGBCx3ueffy7PO+64oyouLo667aKiIpUJKNyEEIfWYkUny5w5c0S0e/XqpV588UU1YsQIef3ZZ59Vxx57rJo1a5bae++91UEHHZTU9urq6tShhx4qon3eeeepG264QeXk5Kjy8nL129/+Vi1YsEBNmTJFvf/++xFW/6JFi+Rv7EePHj1Uc0JXCSFE8Nk+7lQe2ZT5hoYGNXPmTPkb1rAWbTB58mQ1Y8YM+Vs/J8NDDz2kli5dKlb2TTfdJKIN4H6ZN2+eCPIHH3ygXnrppbD1li1bpjZt2iQWenOLNqBwE0KM9HG/+eabIrIQ1cMPPzyqC8Xv96t3331XLV++PKlt3n///fL8+9//PqIbENwfsLrBY489FuFeAcOGDVMtAYWbEOIArUrlkU3eeecded5ll11EoL1A0IcOHeqIfCIaGxsdF8j48eOjLqNfh/88mn8bPvaWgD5uQoiDSR7uJUuWyPO2224bc5m+ffuK71kvG4+VK1fKxGa8bWJ72jVSX1/vuFK0cA8ePFg9/PDD6oUXXlCrVq0S18nEiRPVSSedJNEpmYLCTQix8Sl/yma0T61evVr16dMn5hIrVqxoliO8xg7NgzjGokuXLvK8bt26pLfnXi/W9uBfx4Sl/mwt3JdcconasmVL2DqIRPn73/+u5s+fr7bbbjuVCegqIYRE9J1M9pEpEDOdKAZaP7raYllZWSnPBQUFMbeLuG6gLel46O3BMo7V7V5vz73N6upqx6KHsEOoN2zYIAKOKBS4a7777ju1//77S7RKJqDFTQhpEgjFay6rOh5+268dS2R1mJ572Uxtz708BPxPf/qTHAOEH+J4aA488EA1btw4NXLkSHGv3HLLLeqyyy5L6vvF3dcmb4EQ0nbIksmNMDyIYjKPdbbbo6SkxLF4Y6Hfc1vKsdDbq6mpSbg99zY7deqkrr32WvkObtHWdO7cWZ155pny9zPPPKMyAYWbEGJkOGBX22Wyfv36mMvo97p165b09jA4/Prrr3G3h0lJCHayIJsSwOrOBBRuQohFiqGA4lHIonYPGTIkoRjq9wYNGpRwe71791YdOnSIu039OqJOvC6VeJa/drHk5eWpTEDhJoSk5SXJsm6rsWPHyvN7770X5nvWIOrj66+/lr933XXXpLa58847h8WIe1m4cGHE9pAWjwlS+LFj8emnn4YNNk2Fwk0ICWGKaisrGQY+ZYTxRfMdo44JkmpQMErHXyfiqKOOkue7775b1nVTUVEhMdrghBNOCHODwC+OyJFogo/oktmzZ8vfxxxzjMoEFG5CiJE+br/fry699FL5e+rUqWJ5axAzffnllzux1V6+//57qfiHGHQ3J554otpmm23UJ598oqZNm+ZMVCKMD6KLQQKZmhMmTHDWwd9jxoyRv5ES/9FHH4Ul9aBuClLukVWJVPqMfPeMbIUQ0iYwKeUdQFyPOOIItXbtWhFUiCP82RBL+Jz/8pe/qAMOOEB52XfffcVtcfHFF0eUXX3kkUekLgksdlj0EGX4vxGTjX+j2JR3AEHsdv/+/aV2CtwtAwcOFEscdbxfe+018Yk///zz9HETQtq1p0QIBAIimrfffrsaPXq0CCdSzSHiCM9LpTKgZrfddhOLG0lBSMb57LPPpO4JilahMuDWW28dsQ4EGutcccUVMnhgH5CUg+Sbq6++WrYBSz5T+ILRvPoGgBTb8qp6ddKcV7O9K4S0Ku4/fYIqK8xJKSkG11NdQ1C98K41mZcsB+4yROUGfFlJwGnP0FVCCCGGwZR3QohDticcSXJQuAkhDq1hwpEkhsJNCHGgbpsBhZsQEoLKbQQUbkKIA33cZkDhJoQ40MdtBhRuQogDPSVmQOEmhISgchsBhZsQIlhp7KkpN3U+O1C4CSEO9HGbAVPeCSHEMGhxE0Ic6PowAwo3IcQinVqtVPqsQOEmhLh0mEpsAhRuQogDJyfNgMJNCHGgvW0GFG5CSAgqtxFQuAkhDvRxmwGFmxDiQB+3GVC4CSEO9JSYAYWbEBKCym0ETHknhBDDoMVNCBFYHdAcKNyEEAdOTpoBhZsQ4kAXtxlQuAkhIajcRkDhJoS40m9YHtAEKNyEEAf6uM2Awk0IcaCnxAwo3IQQB1rcZkDhJoS4oM1tAsycJIQQw6DFTQix8KXhKqGBnhUo3IQQB+qwGVC4CSGhWiUpKjeFPjtQuAkhDuyAYwYUbkJICJrQRkDhJoQ4ULfNgMJNCHFgAo4ZULgJIQ70cZsBhZsQEoK+EiOgcBNCHKjbZsCUd0IIMQxa3IQQB05OmgGFmxDiwMlJM6BwE0IcaHGbAX3chBBiGLS4CSECi0yZA4WbEOJAH7cZULgJIQ70cZsBfdyEkHB3SQqP1kAwGFR33nmnGjVqlCosLFRlZWVqr732Uk8++WRGtt/Y2Kh23XVXVVJSknDZefPmqd12202WLS0tVWPHjlVz5syRfcwkFG5CSHqq3UrU+7TTTlPTp09Xn376qRo0aJDq1q2beuONN9RRRx2lLrzwwiZv/5JLLlHvvvtuwuWuvvpqdeyxx6qFCxeqPn36qL59+6oPPvhATZ06VU2ZMiWj4k3hJoQYy5w5c9Q999yjevXqJcL9+eefq8WLF6tnnnlGFRQUqFmzZqkFCxakbWlffPHF6rrrrku47H/+8x91xRVXiKX96quvqm+++UYtWrRIRLxLly5iid9xxx0qU1C4CSFhk5Op/JdNGhoa1MyZM+XvW2+9VY0YMcJ5b/LkyWrGjBnyt35OhaVLl6r9999fXXvttUktf80118jzlVdeqfbZZx/ndbhY4MYBf/3rX2UwyAQUbkJI2ORkKo9s8uabb4rAwqd9+OGHR3Wh+P1+cXMsX7486e0+8MADasiQIeqVV14Rl0cii3vZsmXimvH5fOrkk0+OeP/II49UXbt2VatWrVJvvfWWygQUbkKIg0nu7XfeeUeed9llFxFoLxD0oUOHOiKfLB9//LGqr69X06ZNE3cHJhiT2Y/BgweLW8QLBB37CCDwmYDCTQgxUrmXLFkiz9tuu23MZTBB6F42GQ444AD11VdfiU+6Y8eOWduPeDCOmxDikG2/dSqsWbNGnuGGiIW2gNetW5eScLeG/YgHhZsQIvy8erUa2L9PyusA+IJjsWLFioTb+d3vfqcefvjhpD6zS5cuIoCVlZXyb0SPxAJx3aCqqko1F9nYDwo3IUT17NkzraOAMDxtcbY0ftuvDR9yLHTsdDQfuMn7QeEmhKgPP/wwq0fhoYcekkcqlNiZjNXV1TGX0e9pi7c5yMZ+cHKSEGIkXW2f8vr162Muo99DNmVb2g8KNyHESIYMGeLEUcdCv4dU+La0HxRuQoiRjLXjq997772odUDKy8vV119/7WQwNhc777yzPCOEcNOmTRHvY990rZNM7QeFmxBiJOPHj3cmR1GbJFodE6SY77HHHk4cdXOw9dZbq3HjxkkKPuqmeHniiSfEVdK/f3+1++67Z+QzKdyEECPx+/3q0ksvlb9RgQ+Wt2b+/Pnq8ssvd6r7efn++++lENRqO5yxqVx22WXOZz333HPO67C0UbkQXHTRRSoQCGTk8yjchBBjmTZtmjriiCPU2rVrJa18+PDh4kdGkSlEcvzlL3+JmlCz7777im8a1f8ywcEHH6zOO+88idOeNGmS2m677WRf4BqBtY049TPOOENlCgo3IcRYAoGAevzxx9Xtt9+uRo8eLUWnUMwJIo7wwnQqA6bLzTffrObOnSvuEFjySG8fOXKkuuWWW9R9992X0c/yBTPdmqGFQKZWeVW9OmnOq9neFUJaFfefPkGVFeYklbFIzIQWNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMg8JNCCGGQeEmhBDDoHATQohhULgJIcQwKNyEEGIYFG5CCDEMCjchhBgGhZsQQgyDwk0IIYZB4SaEEMOgcBNCiGFQuAkhxDAo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMg8JNCCGGQeEmhBDDoHATQohhULgJIcQwKNyEEGIYFG5CCDEMCjchhBgGhZsQQgyDwk0IIYZB4SaEEMOgcBNCiGFQuAkhxDAo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMg8JNCCGGQeEmhBDDoHATQohhULgJIcQwKNyEEGIYFG5CCDEMCjchhBgGhZsQQgyDwk0IIYZB4SaEEMOgcBNCiGFQuAkhxDAo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMg8JNCCGGQeEmhBDDoHATQohhULgJIcQwKNyEEGIYFG5CCDEMCjchhBgGhZsQQgyDwk0IIYZB4SaEEMOgcBNCiGFQuAkhxDAo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMg8JNCCGGQeEmhBDDoHATQohhULgJIcQwKNyEEGIYFG5CCDEMCjchhBgGhZsQQgyDwk0IIYZB4SaEEMOgcBNCiGFQuAkhxDAo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxDAo3IYQYBoWbEEIMwxcMBoPKQPLy8lR9fYMq6tQt27tCSKuicsNalZMTULW1tdneFdJM5ChDyc3NVXV1daqqfK3q1atXtnen3bN69Wo5Bvwtsk/Fr42qvt5Ie4y0deGuqKhQffr0kb9XrFiR7d1p9/C3aH2/BWm70MdNCCGGQeEmhBDDoHATQohhULgJIcQwKNyEEGIYFG5CCDEMYxNwCCGkvUKLmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQggxjFYl3IsXL1annHKK2nrrraVRQu/evdXxxx+vPvzww6jLn3zyycrn86mzzz47qe3fd999svzw4cNVe0Ufg1QfV155Zdh2Xn31VTn+2267rSouLlalpaVq4MCB6sQTT1QLFixI6rf+4x//qEaMGKHKyspUQUGB/O6HHHKImj17NpsAKKU++ugjdcwxx6iePXuq/Px81bdvXzV16lT13XffRRzPvffeW36nG264IanzAL8nlsfxJubRaupxQ5z32msvVVlZKUIwbNgwtWrVKvXoo4+qefPmqdtuu01NmzYt27tpPD169FC77bZbVCFds2aN6tChg9phhx0i3t9mm23kuaGhQQbXBx54wNne0KFDVVVVlVq+fLl68MEH5XHQQQepJ554QhUWFkZs65///Kf6wx/+IOIMwYf4+/1+Wf/555+XBwQIAwAGg/bIs88+q4488khVX18vAxuuh2XLlqk5c+aohx56SD322GNq0qRJ2d5Nki2CrYDNmzcHe/fujQzO4PHHHx/ctGmTvN7Y2Bi85ZZb5PVAIBBctGhR2HonnXSSvHfWWWcl9Tn33nuvLD9s2LBm+R4mo4/lXnvtFXe5Sy+9VJbr27dv8O233w57r6GhIfjwww8HO3fuLMscd9xxEeu//PLLQZ/PF8zLyws+8MADwbq6urD3sc2RI0fK+gMGDAhWVVUF2xvLly8PlpaWyjH44x//GKypqZHXa2trgxdddJG8XlJSEly7dq2zDn43vD5r1qykPuOKK66Q5Q8++OBm+x6k+fC3Futi5cqVql+/fuqee+4RKwzgVu6cc84R6w2W3r333pvtXW3X4G7oH//4h/w9d+5cNX78+LD3YTXDtaV/JyzzzTffhC0zc+ZMGAvqqquuUieccILKyQm/6cM258+fL5b/Dz/8oO6//37V3oBFvXnzZrXrrruqWbNmidtQt+vD8YOrb8uWLXJ8SfukVQg3hBoX/Jlnnim+PC/61v3HH3/Mwt4RzbfffiuCAYEeM2ZMzAODW3i4UCDQ77//foTfFowbNy7m+vB177///vL3e++91+5+AMztHH300Wr69OlivLjBv+E2Abwe2i+tQrhxoT/88MPqggsuiPq+npxM1t+JfpS77767nOSDBw8WX7mXtWvXqjPOOEOa22JiDBfDjBkzZF0SHVh8oLGxUb344osxDxOO+//+9z/xm0OAom0Dfux43HTTTeqrr75SN954Y7v7OU466SSZ18EdiRfceX7yySdJXw+Yt9h+++3lN8HcBix5L0uXLlXHHXec6tq1q8wvjR49Wt1yyy3SjJu0UoKtmF9++SV4zjnniC+urKxMfH+JfNzwiU6YMEFeHzx4cHDVqlURPm740+E/xd+DBg0KjhgxQvyu2v/t9h22F5LxccMfvfXWW8tyxcXFwT//+c8R8w6JgN8b6+N4Yz7jtddeC9bX12fgG7R9li5dGjz22GPl+G2zzTYyNxTPx71u3brgDjvsIK+PHz/emTty+7iHDBkS7NKli/weOPe33357eR2Pvffeu13OMZhAqxTuBx98UE6g3NxcOYGGDh0a/OCDDyKW8wo3JnEOPPDAqKLtFm49EPznP/9x3oMA9e/fX96bMmVKsL2R7OTk/PnzZaJYH0c8ttpqKxHhO++8M7hkyZKE4tO9e/ew9Tt06BA86KCDgtdee638zpiUJiGuv/764MCBA4N+v98R4cWLF4cdIq9wl5eXB0eNGiWv7bbbbmGi7RZuPDAYf/zxx857b7zxhjPBjMGZtD5apXBrK1s/unXrFpwxY0bEBe0WbliDhx12WEzR9gr3o48+GvH++++/L+/hAlm2bFmwPZGscIPXX39djrH7N3I/EBXy5JNPxlwfx/aAAw6IuT4GgpkzZ0oUBQkGJ02aFHZ8YG3fcccdMYUblvguu+ziiLbbMo8m3O+8807E+/PmzZP3EN2yZcsW/gytjFYp3D/99FOwsrJSLvDrrrsumJ+fLyfReeedF1Vspk+fLlayDiFbvXp11O1q4catYazbc7hNsAysx/ZEKsKtQ/9effVV+U1wix1NgE8//fS42/jyyy+DV199tYiLvrtyP8aMGRPcuHFjsL2D6wAui++++y54wQUXOJb3TTfdFCHcV111VXDPPfeUv8eOHRtVtN3CveOOO0Z9H9dHp06dZJkXX3yx2b4baUPC7eXuu++WEygnJyfMz63FprCw0LnYO3bsGFyxYkVc4YbvLha//e1vow4SbZ1UhdvLmjVrgnPnzhWXiVuEZ8+endT6FRUVwZdeeil4/vnny8Cq18f2SDiXXXaZHBsIq7aGtXC7r4V+/frFtJa1cJ988skxDy8GVO8AQVoHLRJVgllwRHlEe7zwwgsJ10emXpcuXSSL7N133414H1l7iB4ZOXKk2rhxo4RRxUPHicd7DzHLJHm6deumjj32WIkOQjRI//795fXbb789qfWLiorUfvvtJ9EkiHJA7D5AhuCvv/7Kn8IFoq8QJbJhwwb15ZdfRlwLiIXv06ePZFpefPHFcY8drwUzaRHhhpi+/fbbUR+//PKLKi8vVx9//LGE6MVChz4hvMkLRPv1119Xd999twoEApLAgVT5WMQL+cO+AqQZk3AQaz9gwACpdxIP/FbXXHON/O2uq4HQPoSmIQwzkZggtVuHv33//fft6qdYt26dxL9HC93Tx6d79+5RrweE/L300ktSIkKXF8B1FgteC2bSIsKNAji2WybigUJF++67r8SOQnhjsWLFCnlG3LWXiRMnSiEebOPcc8+V1/AcayBAIkksPv30U3luz4WoYoHkG1jDyRSR0r8TYoO9x/65556Tu6d4QJgwCEfbRlsHhggSlGLFuuNuUN+FeK+Hww47TJWUlKhDDz1UHX744RJzf+qpp6rq6uqUrgXEcGtrntdC66NVJOBAeAFSpaNd0P/+978lJR4FiyZMmBB3W0iiQRU1WC1axL1gW6+88krE67Dav/76a0kx1pl7JMSUKVOc3wMJNvFAAgk44IADnNdQNAkp7kiIuu666+Ku/+STT4q1DQsdpRDaE/p60HcdXu68804R1q222krttNNOMbcDqxulAyDOKDEQDbgeo4k3XF6bNm2SATRelivJEsFWwMqVK52iOpiMQgyq5tlnn5UJR7yHCIRkikwtWLDAmaB55plnooYD9urVKyw2HKGAeA3vYYKsvZHM5CQiDfbYYw9ZrqioKPi3v/0tIlnp559/Dp577rmyDGKBEbft5pJLLnF+g9///vfBb7/9NmKSEqFu2D6SQp5++ulge+OTTz5xYuX/8Ic/OEkwCIfFRD0KdOE9FOlKVGTqn//8pzOx/9FHH0UNB0QSjjsuHNePvh5vvvnmFvnOJDVahXADRBSg4pmeGUeYEuJV9cl12mmnxY3j9qIzzBATrAcCLdzjxo1zqhEilA0JPvpzkMBTXV0dbG8kG1WCY4lkGX28IDDIPkXoGZ51BiqSOhYuXBh1G0jqgJDobfTp0ye48847B4cPH+6EfuIcSDYipS1y3333OdE5ENHRo0cHe/bsKf/GMUbYn5tYwo1rBgk7Or5ex8Zr4Z44caJsH78j3keij/5dTj31VCZDtVJajXADZN1BoHHR46RFWBgSNWB1RyOecMPy03GoOAHdwn3ooYdKyCBC//AZBQUFwZ122kmsk/aafp1qOCDKs06dOlUGPRxD/F49evQQi/zGG2+MGT/sjuGGgEOwIUiwIvF7QTwuvvji4A8//BBs78DyRn4Cjg8GOhzfI444Ivjmm29GLBuvrCuygvUggEQ2t3Aj7PWrr74KTp48WTJYcacDoX/kkUda5DuS9PDhf9ly0xBCCDF0cpIQQkjyULgJIcQwKNyEEGIYFG5CCDEMCjchhBgGhZsQQgyDwk0IIYZB4SaEEMOgcBNCiGFQuAkhxDAo3IQQYhgUbkIIMQwKNyGEGAaFmxBCDIPCTQghhkHhJoQQw6BwE0KIYVC4CSHEMCjchBBiGBRuQghRZvH/Lx9xQc+N6akAAAAASUVORK5CYII=",
-      "text/plain": [
-       "<Figure size 192x336 with 2 Axes>"
-      ]
-     },
-     "metadata": {
-      "image/png": {
-       "height": 333,
-       "width": 183
-      }
-     },
-     "output_type": "display_data"
-    },
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAd0AAAGbCAYAAACBPEofAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjgsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvwVt1zgAAAAlwSFlzAAAYmwAAGJsBSXWDlAAAW4JJREFUeJztnQd0FFXfxm8qCSEJvfciHZQqIIKKhaIiKCJ+iL2h6Itif1VEX0VE7CJYQKzYUBQrCEiVolTpvfcQSICU/c5zYdbZO3e2JLO7ye7zOydnk93Z3cns7Dz332NcLpdLEEIIISToxAb/LQghhBBC0SWEEEJCCC1dQgghJERQdAkhhJAQQdElhBBCQgRFlxBCCAkRFF1CCCEkRFB0CSGEkBBB0SWEEEJCBEWXEEIICREUXUIIISREUHQJIYSQEEHRJYQQQkIERZcQQggJERRdQgghJERQdEmhmDBhgoiJiQn45+mnnw74vfAcPLdXr14+t122bJlISEgQ99xzjygsq1atEvfff79o2bKlKFWqlEhMTBRVq1YVV1xxhfj888+F3Uhq439dvHhxQO/XtWtX+bwbb7zR4/6ZM2faHs/Y2FiRnJwsatSoIffriy++sN2vYH1+M2bMkPtcr149kZKSIlJTU0X9+vXFDTfcIKZNm+ZzX9avXy8eeOAB0aJFC1G6dGmRlJQk/x983uPGjROnTp0K6DgSUhSJD/cOkOJNpUqVRKdOnbQX0H379om0tDTRvHlzy+M1a9YM2j4dPHhQDBgwQOTm5hbqdfD8Rx99VIwePVoKWHx8vNxviMmmTZvE1KlT5c9rr70mvvrqK1G5cmURKtq0aSNKlCjhcd+JEyfEtm3b3PvVr18/8emnn0pBDubnl5eXJ26++Wbx4Ycful+zSZMmIjs7W2zdulVMmjRJ/vTo0UN8+eWXcnGg8uabb4qhQ4dKYcXxhXBjv/H8H374Qf689NJLUrwh5IQUW1yEBIFBgwbBzHJ16dLFsdd86qmn5Gv27NnTdpvt27e7zjnnHLkdfgYPHlyg98rNzXVddNFF8jXKlSvnGjNmjCsrK8v9eF5enuvTTz91Va1aVW7TtGlTV2ZmpsdrGPuwaNGigN4bxwzPwzE08/vvv7tfc/PmzdrnYr9ee+0193ZvvfWWK9if3+OPPy63rVWrlmvu3LmW/fn4449dZcuWldtcd911luf/8ssvrpiYGFdiYqLrww8/dOXk5Hg8jtds2bKlfH7dunVd2dnZBfqfCCkK0L1MIoZvvvlGtGrVSvz111+Ffq0RI0aI6dOni/Lly4vff/9dupfNFhqssP79+0uXKlypcEHjOeEG+3XvvfeKa665Rv79xhtvBPX9srKyxKuvvip//+yzz0THjh0t+wOvwwcffODeZs2aNR7bPP/889KTMHz4cDFw4EDpUTCD14TlDqsbHoaJEycG9X8iJJhQdElE0L17d9GnTx+xf/9+cdVVV4m+ffsW+LXg0nzuuefk7y+++KLWvWrQsGFDMWTIEPn72LFjpYu3KIBjAFavXi2OHTsWtPdZu3atfH2IK1zedlx++eXS7Qxx/fPPPz0eW7Jkibxt37697fMR27300kvl7wsXLnRs/wkJNRRdEjb++ecfcffdd8v4H6wYJChVqVJFJgL9+OOPAb3W/Pnz5XMRV/z6669lwlNBQXIR4rkQCVhevhg8eLD4+OOPpbWL5B8diK2ed955Ml6J/xXWG54TLNLT092/Z2ZmBu19kKwG8vPzxU8//WS7HZKvZs2aJWPFhhWuvgbitt4YM2aMXES8/PLLfu3bli1b5PsiBoy4M57XrFkz6bFA/H3QoEFiz549clu8LvYLng18hmeffbY7Rq3jl19+kedpxYoV5XlbvXp1mTC2cuVKx853I3Hw2WefFbt27RJ33HGHXHwglo/bu+66S+zYscOvY0GKEOH2b5PIxFdM8PPPP3clJCTIbRDva9Wqleuss86ScT27eKS3mO67777rOn78uOX9CxLT7dy5s3xuv379XIXB+D+M1ytTpoz8P0uXLu1+DP+TkzFdg1deeUVul5SU5Dp16lTQYrqIv9aoUUNum5KS4nrkkUdcK1euDOi9EOfF8xHXHTBggPw/EVMvLDhGRqy5e/fu7t8Rf4+Li5N/N2zYUMaUk5OT5bFC7BgxfOM4f/DBB5bXHTJkiPvxChUquNq0aSM/W/yNc3rSpEmOnu8DBw50lS9fXh6fevXqyf3H73isSpUqrt27dxf6WJHQQdElQcHbRXv//v2utLQ0+fjzzz/vkTizZ88e12WXXSYfq1y5sis/Pz+gRConRBcXUjz32WefdRUG42KKnxEjRrhOnDgh78ctLqTGRTojI8NR0T158qSrUaNGcrvLL7886IlUU6dOdYuY8YMEMwjo2LFjXRs2bPD6fPwvFStW9Hg+zo8ePXq4XnjhBZmIZj4PAhVdY/ExefJk92MzZ850C1dsbKyrT58+rsOHD7s/nyuuuEI+1qRJE4/XfOONN+T9lSpVcn333Xfu+3EOjxo1Sr4WPtOlS5c6dr7jB4uBFStWuB9bsGCBKzU1VT728MMPB3xsSPig6JKg4O2ijYsfrCJYCDpwwTIuNrhghVp04+Pj5XMhGIXB+B+uueYay2O4wBtC9dtvvzkiuhBvbNOtWze3oC9evDgk2ecQMViNZuE0/0A0vvrqK9vnb9myxS0+uh+IOAQrEKvdLLoPPfSQ5fGOHTu6rVU1I3r27Nlu6xuLGEOMjcUB/l8dt99+u3y8b9++jp3v2If169dbnnfvvfe6PSmk+MCYLgk5iJ0h+eaPP/7QPl6yZEmP7NhQY7x/Yet8DXRJXWj+gDggQPJXoNSpU8fSsAJx3AsuuED89ttvMqP6o48+Eq1btxahoEuXLjIuimzu++67TzRt2tTSrATH4fbbb9c+v1atWjKuibj4M888I2uHjVgvQEwTNdOIhR89ejTg/UMil+49jX1XY/FGzTXWTkZMHHkDqF1GYxQ8RwcytQHi28b5U9jzvXHjxtraZNwf7Jg9cR42xyBhAxc6ZK4uX75cbNiwQf7gd2TEGiBBJ9TggosL+4EDBxx5vWrVqmnvN5K9CpLxrDbHQPYwhBaJOe3atRPXXnutKFOmjAgl2AeIPn6MxQRE+LvvvpMdsnJycsT48eNF27ZtxW233aZ9DSQZ4ee///2vFKA5c+ZIMUZzDTQ9QXcvJBAFmoSGxCMVJDKBChUqWB4zC77R2ctIkjpy5IhMitNx8uRJeXv8+HGxc+dOt7AX5ny3O3+MEjanFockNFB0SVhA3SUsF1g2Zho0aCCzSpFBHC5QBrRu3TrLvnkDlhysO7XGFNhlNBcGiFjt2rVFUQZiBvHHD2pwL7nkErF582bx1ltv2YquagHiOfiB9Yu6aHSkQuvN119/XZQtW9bvfcGCxA5vHbvMZGRkyFssBubOnev39oU9343FgR3+tPskRQe6l0nIQdOJK6+8Ul6AcEF95513xLx586QFAbEzamTDhdHbGU0x/LG0UXZyzjnnSBGAazeagDu1bt26PhdJcI+i9AXgMzZAGU+jRo1kOYw3UGoFKxmg/Gfjxo0i1BjCfdFFF0mh8/WDHtLF4XwnoYWWLgk5o0aNkhcl1MDqaiG3b98e1k8FdZNoeAH3MsQEfYW9gWb8+H/gPkVHrGgCsUpYr7BA1QENKnB9A9TCmoF7FXFJuEl1ngID1MTGxcVJ0VVfI1QeEKPe1o7Dhw9LlzG8EOhPjVh7UT/fSWihpUtCDi7SwK6D0bvvvuv+PRzxKsR0hw0bJn9/7LHHvF5k4VYeOXKk/B2xxkBcnpEAXL4ADUnQ/MIbkydPlreXXXaZ+z4kV0FokShlHEc7MFQCggvLOByu9c6dO8umFthX7IsOWPOYEoUfw0tS1M93EloouiTknHXWWfIW7sLdu3d7WAkPPvigx0UoHNnLhtjCat27d6/MpEWLR0zNMYBVi37CSBrCPiKeWxR6L4caxGshRhBDTBFCH2U1AQ3HEBnNOIZYlCC2aYBEo4ceekj+/sQTT0ivgtn9DHB88Vw8BsvxhRdekLehBolvxmLslltukQsNA/z/mJT0yiuvyL+xHazy4nK+k9BB9zIJOchM/fXXX2U2KEpf4LaDVYCLLUa7IXsVFyRcoNDmzoiNhRJkhmJ+LSwx7Cus2P/85z8yfonEKOyr0dP4/PPPlyPrvCXrRCoQFiQJIbYLFzMWK/h8cZyQPY3PEVm6cK8igxhJUKqVipgmPn+M7sNCBj8op4I7GgsdtI5EVjA+E8RDER8NF/j/8NkjmxrnBvYR2cVoOWksNtDqET/F6XwnoYOWLgk5KGnBJCDMe8VFC+5bxLXQ7xYXXpSF9OzZU26LC3q4QPLOzz//LKZMmSItOtRnYsrNihUrpJuxd+/e0s0IcdaVnUQLqA9G32T0I0YdLkTl0KFD8jNG6RXKa5AwhTreDh06aF8DFjJc9Y888ogsKYKbFX+j7AbuZCPz15+s52CCTGfEZb/99lt5jmI///77bymiF198scwqh8VbHM93Ehpi0CEjRO9FCCGERDW0dAkhhJAQQdElhBBCQgRFlxBCCAkRFF1CCCEkRFB0CSGEkBBB0SWEEEJCBEWXEEIICREUXUIIISREUHQJIYSQEEHRJYQQQkIERZcQQggJEVEjuphlaTfPkhBCCAkFUTPab8+ePeHeBUIIIVFO1Fi6hBBCSLih6BJCCCEhgqJLCCGEhAiKLiGEEBIiKLqEEEJIiKDoEkIIISGCoksIIYSECIouIYQQEiIouoQQQkiIoOgSQgghIYKiSwghhISIqOm9TAhxFpfLJSbM2Cg+/2OzqFQ6WTzVv6WoWzmVh5kQL9DSJYQUiOVbDovRU1aJHQezxJKNB8Uzny/jkSTEBxRdQkiBmL92v8ffEN68fBePJiFeoOgSQgrEgaMnPP52uYTIOpnLo0mIFyi6hJACceDoSct9x05QdAnxBkWXEOKY6B4/kcOjSYgXKLqEkAJxMJOWLiGBQtElhDgS0wXH6V4mxCsUXUJIwCBhKvtUnuX+Y3QvE+IVii4hxBErFzCRihDvUHQJIY4kUYHj2cxeJsQbFF1CiCNJVIDuZUK8Q9ElhDjmXmYiFSHeoegSQhxzLzOmS4h3KLqEEAdFl80xCPEGRZcQ4lhMl+5lQrxD0SWEBAxLhggpGBRdQkjAHLC1dOleJsQbFF1CSEC4XC5auoQUEIouISQgjmbliNw8/bB6xnQJCaHo7tixQwwePFjUqVNHJCYmijJlyohu3bqJKVOmeH3e4sWLRe/evUW5cuVEUlKSaNiwoXjiiSfEsWPHnNw9QkgQXctG9jIsYUJIkEV35cqV4pxzzhFvvfWW2L17t2jUqJEU0OnTp4urrrpKPPjgg9rn4fGOHTuKb7/9Vm7ftGlTsWXLFvHcc8+Jtm3bikOHDjm1i4QQBzho0xgD5LuEdhACIcRB0cXK9vrrrxcHDhwQ559/vhTN5cuXS/EdN26ciImJEaNHjxbff/+9x/Owfd++fUVOTo4YNWqUtJSXLFkiNm3aJNq0aSPWrFkj7rzzTid2kRAS5BpdA7qYCQmy6C5btkyKLPjkk09E5cqV3Y/ddtttYuDAgfL3999/3+N5r7/+usjIyBC9evWSljDEGVSrVk188803okSJEuLLL7+U4ksIKR6iywYZhARZdLdv3y5vy5cvLwVTBW5isG3bNo/7J06cKG9vvvlmy3OqV68uevbsKa3oyZMnO7GbhBAHOJhp714GbAVJSJBFt0aNGm53MVzEKoYVXKtWLfd9cD1v3bpV/o6Yrg7j/tmzZzuxm4QQB6B7mZAwi+7ZZ58tzj33XPk7XMl79+51P/bZZ59Jt3JsbKy499573fdv2LBB3qakpIhKlSppX9cQaWNbQkjRzl4GdC8TYk+8cAhkH//f//2f+PXXX6VYouwHmcewfKtWrSpeffVV0bVrV/f2+/btc7uk7UAJkWFBE0KKdgtIAyZSERIC0U1ISBDt2rUTc+fOFVlZWW6XsiGsKAcyg22Aer+Z5ORkeZudne3XPiAObAfc2VWqVPHrdQghhUmkyuXhIySY7uWDBw/KUiHU1qLUZ8GCBeLkyZNi586dYsSIEWL16tXiiiuu8MhehrsZGBnLOowie2NbQkh4yct3icPH6F4mJKyW7siRI2VzjAYNGoiff/7Zbb3CrYzOUrAwb731VnH//feLPn36iNKlS4tSpUrJbU6csHdVGY8ZFq8vdElc/ljBhBD/gOCiAYY36F4mxB5HTEijzeOwYcO07mKUBCHDOTMzU/z0008esVxYyXYYj1WoUMGJ3SSEBNm1DOheJiTIomvU36L1ow64kJFYBYwyocaNG8tbCLFdq0d0tgKwoAkhRXN4fXysZ4iIli4hQRbd9PR0ebtr1y7bbQyxTUtLk7dly5YV9erVk7/Pnz9f+5x58+bJ2w4dOjixm4SQIGQu1yif4vE3S4YICbLoXnDBBfJ2/Pjx2seR0WzU2hrbgquvvtr2eYjPTps2TSZRDRgwwIndJIQ4bOkiD7J6+ZIe99HSJSTIovvoo4/KkiFMDLr77rvF0aNH3Y+hm9R1110nM5H79+/v4YK+7777RGpqqqzxHT58uMjLy3NbzEi4QgZ0v3796F4mpIjGdMuUKiHSSiZ63MeYLiFBFt2WLVvKPsoYUPD222/LbOVWrVrJPsxdunSRvZlRUqRatNgOZURxcXHi6aefltu3bt1a1K1bVyxatEiO+Rs7dqwTu0gICYJ7uXxqCVEqybMIgu5lQuxxrAAW1uzSpUtlpjIyk1FChCH06J8M4YQVbJQJmYGLGXW9GGKfm5srm2qg1Gjo0KFizpw57ngxIaToWbrl06yiS/cyISHoSAWaNGki3nvvvYCfh4YaGOVHCCleMd3yaUkiJSnB4z66lwmxh62eCCEFdi+X07iXc3Lzxamc0/kZhBBPKLqEEL+AkGZk5VjcyymK6AJau4TooegSQvzi0LFTlvtOW7qe7mVA0SUkBDFdQkjkkpFlFV2UDKkdqcDxE54WMSHkNBRdQohfqK5lkFYyQTbIUKGlS4geii4hxC8yjlst3fSSie4RnGZYNkSIHoouIaTAlm56SoLMVlZhgwxC9FB0CSF+cVSJ6SKUm5qUIE5pRTeXR5UQDcxeJoQUyL2MnsuxsTGiREIsx/sR4icUXUJIgdzL6SUT3POy1VpdupcJ0UPRJYT4xRHF0k1P+Xe6kFqry0QqQvRQdAkhhbJ0gWrpZmazTpcQHRRdQkiBY7oGnDREiH9QdAkhBepIhXIhA04aIsQ/KLqEEL84anEv21u6TKQiRA9FlxDik5M5eSL7VJ5tTLdUMgfZE+IPFF1CSMBWLihtyl6me5kQ/6DoEkIKNGHIm3uZJUOE6KHoEkJ8knFc33fZrmToRE6eyMmztockJNqh6BJCAm6M4cvSBVnsv0yIBYouIaRg7mUvHakAhx4QYoWiSwgp0Fi/1GR79zJg2RAhVii6hJDAu1ElJ4g4zPbz4l5mMhUhVii6hJCALd00UxKVrmQI0L1MiBWKLiEk4AH25iQqO0uX7mVCrFB0CSEBu5fNjTEA3cuE+AdFlxBSqLF+IDkxXsT8G+KV0L1MiBWKLiEk8AlDins5NjZGpJRQu1Jxpi4hKhRdQkjAzTHM3ajsyoZo6RJihaJLCPFKTm6+yDqZ59XS1TXI0HWxIiTaoegSQgLuRpWmxHRBlTLJHn+v2ZHBI0uIAkWXEBJwNypzC0iD5rXLePy9cU+myMxmXJcQMxRdQkihxvoZtFRE1+USYsXWwzy6hJig6BJCvHJUN9ZP415uXstTdMHyLRRdQsxQdAkhAVu6anMMw+Vcp2Ipj/uWbT7Eo0uICYouISTgAfa6RCrQso6ntbtsy2Hhgp+ZECKh6BJCArJ00fIxPk5/6WhRu6zH30ezcsTW/cd5hAk5A0WXEFKoblRmWijJVIAuZkL+haJLCPHKEcW9rOtGZdCgappIToyzuJgJIaeh6BJCArJ007xYuhhsr2YxM4OZkH+h6BJCAhrrpysX8uZiXrczQ2SdzOVRJoSiSwjxBZKhfHWj8pbBnO8SYuW2IzzQhFB0CSGBJ1L5snQ9M5jBctbrEiKhe5kQYktuXr7IzM71O3sZlEstIaqXL+lxH5OpCDkNRZcQYotuYIGuG5VKS8XaZZMMQk5D0SWEBDhhyLt7WTf84FDmSbHjYBaPNIl6KLqEEL8zl/1xL+vG/IHNe4/xSJOoh6JLCLHliFZ0fVu6lUonWe7jbF1C6F4mhDgwwF4lNdkqzJma1yIk2qClSwgJaKxfmkZQVZIS4kR8XIzHfUc1SVmERBsUXUKI32P90Fc5McGzt7KOmJgYizjTvUwIRZcQ4oWjamMMP1zLdi5mii4hFF1CSAAxXX+SqAwouoRYoXuZEOJ3yZA/jTEMUhWB1iVlERJtUHQJIQGM9fPf0mVMlxArFF1CiP8ThvxojGEn0IzpEkLRJYR4QXUJB2LpMqZLiBVauoQQLfn5Lkv2sj81uraim5UjXC4XjzaJaii6hBAtx0/mygH0TpUM5ea7RPapPB5tEtVQdAkhfsVzC5tIBRjXJdEORZcQokV1LRfWvQwouiTaoegSQhwddmBXpwvYf5lEOxRdQoj/7uXCWrpskEGiHIouIcR/93Igdboa0aWlS6Idii4hxC/3cmyMEKWS4v0+WrqkK1q6JNqh6BJC/LJ04S6OhfL6SYmEOJEY73mJYSIViXYouoQQLaorOBDXsl1cl+5lEu1QdAkhfg2wD2SsnwGHHhDiCUWXEKLF0gKyAKKrlg3RvUyiHYouISRk7mUmUpFoh6JLCAmae5kxXUI8oegSQrQczXbAvaxautm5PNokqnFcdDG668MPPxRdu3YVZcuWFUlJSaJJkybi6aefFtnZ2drnLF68WPTu3VuUK1dObt+wYUPxxBNPiGPHjjm9e4QQP8jLd1kEMpAB9gZpyZ51vYzpkmjHUdE9deqU6NOnjxg0aJCYNWuWqFChgqhZs6ZYs2aNGD58uDjvvPNEZmamx3OmT58uOnbsKL799lspuE2bNhVbtmwRzz33nGjbtq04dOiQk7tICPEDnTg6Y+lypi6JbhwVXVinU6ZMkWI7d+5csXbtWrFu3TqxYMECUaVKFbF06VLx5JNPurc/cOCA6Nu3r8jJyRGjRo0SO3bsEEuWLBGbNm0Sbdq0kWJ95513OrmLhJACt4AsQMmQYh3Dgs46SRcziV4cE92tW7eKMWPGiJiYGDF16lRpvRq0a9dOvPTSS/L3CRMmiPz8fPn766+/LjIyMkSvXr3Egw8+KJ8LqlWrJr755htRokQJ8eWXX0rxJYSEecKQA9nL4CjjuiSKcUx0P/30U5Gbmyuuvvpq0b59e8vjV155pYzrjhgxQpw8eVLeN3HiRHl78803W7avXr266Nmzp4wRT5482andJISEYIC9t+cwrkuiGf+7l/vgt99+k7dIiNKRkpIinnrqKfffu3fvltYxMFvFZnD/119/LWbPnu3UbhJC/CCjkBOGDFKVRCrAWl0SzTgmuitWrJC3SITKysqSGcxIkjp8+LCoV6+eGDhwoEykMtiwYYNbjCtVqqR9zVq1anlsSwgJn6XrRJ0uoKVLohlHRBfu4n379nkkR23cuNH9OMR33Lhx4r777nPHfY3ty5cvb/u6KCEyXpMQEj5LNz4uRiQnxjkU07UKOiHRgiMxXXMZUP/+/aUIwy18/PhxKa4jR44U8fHx4tVXXxWjR4+W28EaBigTsiM5OVne2tX36uLAdj9wZxNCCmbpwrVsJDoGAi1dQoIgumZRPHLkiPjxxx/FVVddJUqWLCnLhx566CGZRAWeffZZ2fQiNvb0W3v7IiOJSu7kmW0JIeHJXi6Ia9mYqVsigTN1CXHUvQxxNbjmmmtEs2bNLNs88MADUnBRIvTHH3+IUqVKyftPnDhh+7rGY4bF6wvU+doBa5cQEroJQ2Zr92TO6YoFwEQqEs04YkKmpaW5rdEWLVpot4EbGQlVYPPmze5Y7sGDB21f13gM1jIhJIzu5eTAM5ftBJsxXRLNOCK6CQkJom7duj7dxYjrgsTERNG4cWN3PNiu1SPaQYIGDRo4sZuEkIK6l1MKZ+maYfYyiWYcC5YaDTEWLlyofTwvL89d+gOLF8MQDMt3/vz52ufMmzdP3nbo0MGp3SSEhNi9nKaIrq4ciZBowTHRve666+TtDz/8IPstq6D9I7KZ4Sru3LmzvA/dq8D48eO18dlp06ZJt/WAAQOc2k1CSIjdy7R0CQmC6Pbo0UOO88Okocsvv9zdLAOgoxQymMFjjz3mdjOjbjc1NVVOGMIUIljDYNeuXXJaEUqP+vXrR/cyISEkJzdfZJ86/V00oHuZkCImuojlfvbZZ6J58+bS0m3ZsqXsToXYbZcuXWTc9vrrrxdDhgxxPweTh95//30RFxcnS4ow6KB169YyPrxo0SL5/LFjxzq1i4SQgraA1DS5KKily0QqEs04WgCLdo4QyxdffFGKLnor79mzR7Z/nDRpkvjoo48sNbdwMWP0H3o2Y2DC8uXLRdWqVcXQoUPFnDlzRHp6upO7SAgpUAtI57KXj2XniPz80zX4hEQbjvVeNsA4vmHDhskff8HsXIzyI4QUzbF+aQ5mL0NvMVO3VCGsZ0KKK2z1RAjxOcA+3UH3MmDZEIlWKLqEEJ8x1/QU59zLdu9BSDRA0SWEeJBxPLiJVICWLolWKLqEEK+JVEkJcSIxIfCxft4Em6JLohWKLiHEq+u3MDW6tjN12ZWKRCkUXUKIV/dyYVzLgIPsCfkXii4hxKuliwH2hSEhPlYkJ3q6pznej0QrFF1CiFfXb0EH2Jth/2VCTkPRJYR4bQNZmAlDBhRdQk5D0SWEeJ8wVEj3MmD/ZUJOQ9ElhLhxuVwhci/n8qiTqISiSwhxcyInT5zKzXfcvay+But0SbRC0SWEeK2fdcK9rJYdMXuZRCsUXUKI1wlDjriXldc4ohmqQEg0QNElhHidMOSEe7lMKU9r+fiJXHEyJ49HnkQdFF1CSNDdy+VSS1juO5R5kkeeRB0UXUKIbY2uU+7lcqWsonvwGEWXRB8UXUKIm0OZnqIbG+OQpZumEd2jFF0SfVB0CSFuDiou39KlSog4KG8hKauxdA/R0iVRCEWXEGIruuU1sdiCkJ6SKK1mb1Y1IdEARZcQ4ubA0RM+3cIFAdZyGcXaVQWekGiAoksIsRVCXdZxQSmrvBZFl0QjFF1CiL17OS3JsaOjCjhFl0QjFF1CiCQnL18cPnYqaJau+lqs0yXRCEWXECI5rMkmdtS9rHSlYvYyiUYouoQQ27rZYFq6sKrz8108+iSqoOgSQiQHNKJb3qHsZV0iVV6+S9sBi5BIhqJLCLFNbAqmpWv3noREMhRdQohWANHMQq2tddLSBUymItEGRZcQom2MUcahFpDeulsdZFcqEmVQdAkhQW+MAXRW88FMT6EnJNKh6BJC9KLrYBIVSEqMEylJ8R73HVLqggmJdCi6hBBt9rJTww68dqXieD8SZVB0CSE2lq5zLSDtRvyxQQaJNii6hBDZAvLI8eC1gLR7TWYvk2iDoksI0Yqfk40xDDhpiEQ7FF1CSNAbY/z7mp79l9kcg0QbFF1CSND7Ltu9ZvapPJF1MpefAIkaKLqEEK3F6eQsXQN2pSLRDkWXEGLpRoVGVKVTPF3BTqCznpnBTKIJii4hxGLpOt0C0q5kCDCuS6IJii4hxCJ8wchctp80xK5UJHqg6BJCLN2ogpFEBdJKJoh4xYJm/2USTVB0CSFBH3ZgEBMTY0mmOkRLl0QRFF1CiMa97HzmsgG7UpFohqJLSJQTqhaQBuxKRaIZii4hUY6uBaTTY/3MlC3lWYrEkiESTVB0CYlytI0xgmjpqtOLWDJEogmKLiFRjpq5HKyxfnaWLlzbuXn5QXs/QooSFF1CohxdyU4wY7rqa7tcp4WXkGiAoktIlKMOO0AnqmC0gPTeIMNqbRMSiVB0CYlyDlhaQCYGpQWkAYcekGiGoktIlKNausF0Ldu9Pi1dEi1QdAmJckLZGMNu6AG7UpFogaJLSJRzQEmkCralmxAfK3swm2H/ZRItUHQJiXJC7V7WTTHac8SaQU1IJELRJSTKW0BmZOWEXHSrlCnp8ffuQ1lBf09CigIUXUKimMPHQtsC0qBqWU/R3XU4O+jvSUhRgKJLSBSjS2DSJTo5TdWyyR5/7zuSLa1uQiIdii4hUYxu2IDapjEUlm6+C8LLuC6JfCi6hEQxh49ZLd0yIbB0qyiWLtjFuC6JAii6hEQxYbN0lUQqQNEl0QBFl5AoRp2lWyopXiQmxAX9fSukJ4l4pdXkrkNMpiKRD0WXkChGdS+HwrUM0Nu5suJipqVLogGKLiFRjGrplk0NvmvZzsXMWl0SDVB0CYliDimWbijKhezKhlirS6IBii4hUYzaHANj/UJFFaVsaPfhbJGP2iFCIhiKLiFRjJq9HE5LNyc3nyP+SMRD0SUkSoHIZWbnhk90NWVDO1mrSyIcii4hUYquRrdMKBOpyrFWl0QfFF1CohRdN6pQWrqVSyeLGM9SXbGbtbokwgmq6K5Zs0YkJSWJGPWbZWLx4sWid+/eoly5cnLbhg0biieeeEIcO3YsmLtGSNQTrm5U5mH2FdOTPO5jrS6JdIImuvn5+eKmm24SJ09av9gG06dPFx07dhTffvutFNymTZuKLVu2iOeee060bdtWHDp0KFi7R0jUo9bogrIhmKXrba4uu1KRSCdoojt69GixYMEC28cPHDgg+vbtK3JycsSoUaPEjh07xJIlS8SmTZtEmzZtpJV85513Bmv3CIl6tMMOUkJn6eoymHcf5jB7EtkERXTXrVsnnnzySZGcbJ0kYvD666+LjIwM0atXL/Hggw+6XdDVqlUT33zzjShRooT48ssvpfgSQpznYJj6Lnur1d15MEu4XKzVJZFLbDDdys8884ztdhMnTpS3N998s+Wx6tWri549e8ov3+TJk53eRUKIJpEq1K5lUE0R3exTeSIjKyfk+0FIsRXdV155RcybN0/ccccdomvXrtptdu/eLbZu3Sp/R0xXh3H/7Nmznd5FQkiYu1HZuZcBk6lIJOOo6G7YsEFmHteoUUO8+OKLXrcDKSkpolKlStptatWq5bEtIcRZDoaxG5WdexlQdEkk45jowhUMV3F2drZ45513RGpqqu22+/btk7fly5e33QYlREbCFSEkBO7lcIhuGauly1pdEsnEO/VCr732mvjjjz/EDTfcILp37+5126ys0xmKKBOyw0jCgoj7C2LBdsClXaVKFb9fi5BIpyi4l0uWiJfva14A0NIlkYwjli7KfB577DHpKh4zZozvN409/bbemmYYGYzGtoQQ5ziVk2fpu1wuDIlUOmuX/ZdJJFNoSxfieMstt0jrddKkSaJs2bI+n1OqVCl5e+LECdttjMe8lR2poNa3IFYwIdHG4eOaGt0wWLqgWrmSYvX2DPffdC+TSKbQZuRbb70lZs6cKa6++mrRp08fv55jxHIPHjxou43xWIUKFQq7i4QQP7pRlQlDTFc3bYjuZRLJFFp0v/jiC3mLRhZwF5t/0MrRwLhvwoQJonHjxvK+zMxM21aPaAcJGjRoUNhdJIQoHNJ0owqbe1kpG0KdbtZJT9c3IZFCod3LzZs3F7m5+i8IhhYsW7ZM/t6pUyd5i7gvXND16tUTGzduFPPnz5eNMFRQ6ws6dOhQ2F0khPhIogqne7mqpmwInakaVE0Ly/4QUqRFF+0cvU0QMqzdOXPmeDwGd/TIkSPF+PHjLaKL2Oy0adNkEtWAAQMKu4uEEIVDmeHvu2xQo3yK5b71u49SdElEErbU4Pvuu0/W8mLC0PDhw0VeXp68f9euXTI2jDaS/fr1o3uZkBCM9UtNDn3fZYPalUrJMX9m1u74N7GKkEgibKKLmtn3339fxMXFiaeffloOOmjdurWoW7euWLRokRzzN3bsWBGpnMzJkz+EFAXRDVcSFUiIixUNqng20/mHoksilLAWwcLFjPF/GGKPuPDy5ctF1apVxdChQ6U7Oj09XUQi3/25XXR+9EfR9oHvxZvTOEWJhL8bVbjiuQaNqnt+19fsyOC0IRKRONaRSgfm4voa04VtMMovWkBW5vNfLhdZJ09buW//uFb0aF1N1Klk3zaTkGBbuuXCaOmCRtXSLdnV+4+eEBXT/a/TJ6Q4wHZPIWbD7qOWTkArth4J9W6QKEdNpAqne1ln6YI1O46GZV8ICSYU3RCzbf9xy30Hjtp35iIkFCVDZVPD615uWM1aHgQXMyGRRlDdy9HE7kNZYvS3q0VG1ilx44X1RafGFf0W3X0ZFF0S2r7Lx07khn3CkJmUpARRs0KKx/eDoksiEYquQ9z/3iKxattpN/Gi9QfEj09drB1btu2AVXT3U3RJmLtRhTuRCjSunu4pujtp6ZLIg+5lBziYedItuCA3zyVmLN+t3Xa7xtKl6JJwd6MqG6YWkGYaKslUEOBj2Tlh2x9CggFFN0gXsQ27M7Xb6izdfYzpkjBbuuF2LxuWrsq6XUymIpEFRTcINY9g427rxeJoVo522wMZJ1mTSMJWLlRU3Mu6DGY2ySCRBkXXAY5oZpPC0lVrlLdrrFxwQjNQnJBgcTizaFq6FdKTLJOOmEwVfbhcLvHr37vE+7+tFztsrpnFGYpukET3aHaOJSvZTnQBGgEQEgoOavouq72Pi1JnKhJdvDltjfjPe4vEy9+uFlePnCknTkUSReObVszRuYx1cV1duZABk6lI2Gp0i4CVaye6G/Zkipzc/LDtDwk9k+ecnqUOUNo2ccaGiPoYKLpBsnSN7lO+kqgizdL9bdkucevrc8WjHy4R+zKyw707xI/FYFHIXLZrBwnB3bhHn5RIIo9j2TmWRL9pS3ZG1MKLdbpByl4G65WLm65cKJIsXVwc7393kftvfHneubtDWPeJeIKF0PIthz3ua1yj6AwWaVTd2plq7c4MbZIViTz2HsnWGjWzV+0VF7WsIiIBWrrBtHSVcodt+4/ZvkYkdKWavsyzNnnuP/vkgAdSdPh9xR7Lfd1aFJ2LWc0KpURyoudcX8Z1o4c9R07YTmaLFCi6QRRdWH75+aczmCE++4/qLeJIsXS37rMuKrzFsUn4F0bpJRNEq3rlisxHERcbI85S+jCzbCh62KOxdMGsVXtsr7PFDYquAxy2ORmyT+WJXYeyfGYuR4zoagSWolt0QJ34n+sOeNzXtVllER9XtC4DapMMdHvLzYucmB6xZ+9hveiiy9+0xTtEJFC0vm3FlCM22cvmpBWfouvFCi4u6Nzn3lzqJLT8sXqvyD3jeTG4sAi5lg1a1C5rWbyyM1V0sNfGvRxJLmaKbiFBVp06scXM+jMZzL4sPli6ajON4kSmJuvQV8Y2CS1qP/CkhDjRsXGFIvcxnF3HU3TBX5sOhWVfiCe4RiGxDV6TULqXwcptRyIik52iW0h8xRn8tXTRlcqbeBd1ttpYtHQvFw1O5uRJS9cMxk8mJxa9AoYa5UtaOlNFi+giaezDGRvF4g0HitwiHAbGwDFzRN8XZorOj/5oO9TF6ezlSLN2KbpBFt31ZzKYVfGJiYmsDOZt+/SLCopu0WDB2v0i62Sex30XtqgsiiIxMTHinLqe1u7fmyNbdPcczhYPT1wiOzC9+M1KceOrc8VX87aKosQXc7e4P4e8fJd44qO/HK9O2OtDdL9ftN2dnFpcoegGKYnKYPO+YzIJRBWfBlWs9YgHirHo6pKojIUEy4bCz3TFKkGWMJKoiiqq6EKUdtsk2RRnTuXkiXd+Xisuf3a6+EFJFHp/etHqxPSbkvmOVrffLSyY5Zmbly9++WuX7LEMAQfHT+RYetBXLZtsiflu0VRJFCeKnm8pgpKoDJcMXMxqrKJ1vXKW5JDiPOLPzr1suNbVWakkdOCiNlOpz21bv5xITwn/ZCF/RRf8temgqNK6ekjeH9bUh79vFDNXni5VQegHopBeMlHceslZ4uqOtQr9HnAf3zNuoZi3Zr/2cSzUETtNK5kgwg32Y+nGg5b7P5q1UfQ7r7aIjdW47rz833e+NV8sOJNJj8XfG3e019boXtm+pnj7x7WWa03dyqmiuEJLt5AcPu476xhfXDU8g4uK6mIuzmVD3tzIdDGHF3SgUpPcimLWspnG1UuLEgmel6e/QxjXnTBjg3hpyiqxeMPB04vmw9nSCttxMEsM/+xvR87ptTuP2gquwZqdRWPgw5x/rJnvYMu+42LOP/sCPh8XmErXcH1EGA7HWKX9WeUt923eW7wtXYquw5ZufGyMdN2Z0SUcYKVWRmk0X5xF15vLx1cSWbSDfrMorQpWLeq6XdYL9wXNi65rGWDqUbOaZQqdTIVmIAPH/CHueWeh32VHeWesXDuwgP5znXexNLN000Ex8qsV4tPZmzx6CCML2BdrtjsjugeOnpB1rrvP9A0IlFkrPZPwzHg7VjqWbfZsQ2o0QNHFc2tXLCUqlU7yuG+rTf5IcYHuZYcTqTAMvFRygsdqbLXmi4MMzYrpSeJQ5slin0iFY+CthKC4f0mCCYRkyPiFclJVkxrpYvzgjo67fbcf8LzQlkqKF5XLeMbKiiJn1y0rlphcmhAp5AeUSIgTC9ftFyXi40SrevAY6V2bm/dmimETFotTZ4Ruy75M8c1jF4oEH81AFq0/IA74qJvf4qelC3G+/a35srkD2HUoWzzQu6l2oYqFBjqEmd/7nx1HhBMZ0f1fmiX3IT4uRkz6T2fRvJbngsYbWAyqme9qkh4s1QZVrXkqOlZus4ounl+yhKccYV8xAQvCa67f9RbKKg7Q0nU4kap0qRKifhXv8QaUQ6QkJYgKaZ6Wrq8venFq/1iUa3VhWeYUkQ5Hr3y32j0aEoszZIg6jdqgpEb5FFuhKspxXXg30VHr1jfmidvfnC8GvTpHPPP5Mtvnfz1/m1twDVfokg3WuKSKmtCEQ6VOYvJ1zoMTp/LEU58ucwsu+HLeFncpkOomrVUhRTSpUdrxFphv/LDGvQ+4HfX1yoAXhr7qcj+aucnv11u1zbqQ0LmXK6Uny1hxrYqlPO6neznKUd3LZVISRX1NZrKZmhVS5G2FdE+3SXG1dO0yl4taV6qM46fEY5OWivMe+VGcO+wHMXXR9rBnri5TSmHUCUDBsHQhusUBXZOMRyctkZaowRdzt2oFEIlQ05bs8Nl7WlfPjPGUatJj+waescUtfsQVx/+yzhJaQVzYSBhSLd06lUpZWmBCYCDeBQVW6qINnq0//9p8yGdpjhnEXFXUcwjfJbPXzo6jWTna6wWaCKn7ZHhj6iiiezDzpGzGY4BWu0jyKi6tQmnpOm3ppiSKi3wkqTQ809C9QlqSJe4SzIJ4nKxYURb25MTrINXf+JL4ElW4hrJPhbfxx5zVe0Xv/82QxfVICDmZky/+98VyeZENFxjQrianOL2Kx/m0Q7nw1ziz6Cvq4LsEITKjlpSA+ZpkJMRRdS0FZ6zY7fU7Bjeq+h4921QXtZX9gJh6+x6hc9J7v63XPobvIOLGajIW3KjqmEVsZ9T6F4R/tmeI40rTHfz7+P76yyxFdBEGufOyszzug0fh6/m+64pXaVzLAJ+V0b3PwIjlqpau2cUMz9ClT/8qbnhljrj+5T/kQraoQ9F12NItXSpRzv588tqWonq5klrX8oDz62otXfSYDVZXKnzJLn3qV3HV879Lt1xBV89wDV3y1C/iP+8tEr1GTBf/bD/iV8x2h2JthQqI6vDPlok7315g6W+Ni2s4M6t1rkNczJ10fSNkgfOqOFq6dqVDKvPWWrNnMfjc7uKOdoJ2TFu80xJXvOTsqlIQzWCxZAwzUYGoj/jc061sZsPuo/K5Zte3W3Sre7qXC+tiVq1cA9TI+gOscbjlzaDEp3urahaX+68+vAhgpZdjry6SKpU+benWrmg9X3HNwfdkzLer3ZUhuDZ9WcQaiuig6BaSI1lW9zJA7dpPT18sFo/uJaY92U1MuK+TGD+4g/ju8QvdNWZIpFIxMpjNWY6FBa62F75aIVtNGtmDPy4t2MSOcT+vk1YiwMX8f1+usCQ2VCtrXWyES9ye+WyZ1zhpIG42p8GCRQUX8+0OHitd5rgR3ogU0YW72Wx14rvz81K96AK79oWI9auu1M5NKsnEtlqaC7+dV+LbhdtlqZEdsFx17mlY9WgGodblFiaZyuyKN7N0k38uZrW+G3RtXlkkJsSJXm08a6YherqyH3UbfzHcy1XLlpSLH/XYI7MbDTrM/BKABR8uKLqFAK4M1XUDS9dMUmKcvMi1qV9edGhU0SMzVXUvA2RrwhptNXSqGDJuoSPuEpRKqKvIFVsL9kVesfWwJcli3U5Pt1CnJhUtzwtHxiFc2j9o4npm9oYxjm5nwTjpYtYtdoqXpet71i88FuaL+bw1+0SGl8Qfc3cuiNJPS3fKuDA6LqnWZ48zzThqV9C4ODUeHgj+y9+t9rq/63dnakvsaldMlQlujZRGMnARFwRYgubsbxXDxYzs5ic+/ku89v0/lu5x6iIELl8j7qwrO9OJtL+WrorhXsboSfWcxeelaw2K/xdhuqIMS4YctHLNlq4/qO5lAFeowYwVe8QH0zeIOy5rWIi9FLK8QsWfRBCVw8dOapO91LgkYtaw4s3bhqNWd/nmw7YuPoN9XkaJBRPE6tTFirnURQhnmleoxz0xPlZU0px3RRVk9JZPK+GR2Y+LsbqIRNlKyzOJV3auZYNNe46JTXsyZQMMZDgbqNZUcmKc6Nq8kvwdZYDqfmzRLCRXbDtsSShCkw/DO3T6/TMt03IQdjIsXMR1/zRZqFg0Q0B9lTrpPClqv20zP/+1S9SqUEp2xTJaMSKRDx45iD9qetXa6PObVnZnvsMLgRIn8wIHMfP+59fRvh/EcE8ArTwN97LhejcvRrGIz9fE5nEXFk/9O+v3oShAS7cQGKUeavKHv5RLK6EdfGBmysLthU6uWrD2gM2FPTDsREIFX2TVhRkO9/JizSq/ZIm4IuFehqWjxlpDYelWL18yoJZ94QYX+Lu7N3L/jTK7cYM7SjE2M3/t6YUlLDXVfazLrYDQmAUXqAu0i1pW8ZjCpMZ1dQtXnVV6x6Wei2ZY02rdqzlhTM1gxvYFOSdQXuUNCOrQ9xe5BddYvBjW7fu/bfB4DHRtdnoRYligav9uLBbMmcUFtXJBFVMtueXY7ztm2ywlkCSxcEDRLQBYsUG0dH2XVfeyN7ByVbtS6SwV1aUbuIvJ+uVDUhFiWIHgb0cfXBBV0fVVVhQM1JrMepVTLT2gvQ3NDgR0+7nx1TlyUow/Ddl18VzzkAynUC3d4uRaNkB+xOSHuoiXb24rpjx2ofwcOzTynAMMVyMEF4KhLmbu6t7Q0jjfn0VgT6XPMxaTvkImasigbKlEcX7Tf4XK7rwzi4oqur7OFzsWKee/askD3cLv9e/XyMXoV0o2MhYvGAdp5gJlUhUWLnNW7yt0PDc+9nRjDAM1gxkWvF2JJUIG/pQvhQuKrp8g7vPIh0tE9+G/ia6P/yxe+GqljXvZu4iqqA0ydPygZFQGAgTbzsWkc495w5+2dXClwS1UU7m4w61UmHrDQEFsTa15bV2/nCV5bV9G4S3duf/sEw9NXCKTZ9BY4bqXZskSJW94y0jFgs6p0jG1MYn6uRQX0DTiknOqunMizm1YwXKxx/GfsmCb5Xzs1rJKwL2m4cI+VxF2tWwIwqnGQBEfNYNKBlixamtYFbPo1q6UKpIS4ry+rj+LbXVAARYRasax3eJ68DsLLfHtWy9uIK1bMx0bVbT0yP59hT5RbaWSRxLv5ZhULJ3k4ZHRZTDbAeM8GLN+nYKiG8CF9ftFO9yWw/Ith7SrKbSBDARdBrNO8AtaW7tQ41ouaFzXH0sXlhS+LDU1iSc7D4bO2l21/Yg7W9vc5KCyKU7kREMSfC6jvllpSey5e+wCMXHGBlvx9JYcg+ejFrqwZGRZ23MWR0tXR7sGFYR6zX7x6xWWAQJwf6L7mzfRhYDfd3lj0aZ+ORnHhQt+5KDWlhiqvnTl3+8Qkh43KN+RxjUwuOF0MqU3zIIOgTZq+QtaNgSrUrVi2zesIC5u6d/iQxV5LEKuaFfDsh1aN6oLoNmr9lqqL/A9UGt0u3gZLal+T1X3si+KchYzRddPjCQN84VxycZDlt6p+NIGgtmFYgcuwObEisImURkEMpcS4oJpK74wLi66i4xTLmbEch79cIkY9Moc27o8Xbu/VvXKyRW0GpcvTIMMxNx1xwWr7VHfrBJPfvK3JS6GC5Avy2WTA3Hd4l4u5A0kHTVT+ger9aTGaDjQqm5Zbb4FXLmv3tpW3HbJWWLCfeeJRaN7iZ+eulhWG6io7mX1PXXNTgxX8Vk++hLXVaxoWMhmcL6Yh7fj99FTVsk5vE98tNTSfEYXz23XoLy4tFU1y/1YvKDhhTdu7tZAlgnpuKC5p5Cj14BaHwxPlzrp6tyG5T3itnZJVEaiGXqG+8vCdQcsffGLChRdPzmnjrVB+Nx/9loylwPtaVtFiTWBAV3qWBKsEDMMFLi+dGn1BoEkZ2BFr7qbdAsM48Kku7ib42gQns/+2CxdsQ9+sNhnViO2/2PVXhk3xdSYqYt2yPKApz/9W+vKVeskEY/CF7xiuvV4F9TaxfF984d/vG7zzYJt4vM/Nnvct/NglqW+0IlEt0grF/KFamGpoKlF5zPla3CLwj1tBnHet+48V1rC/oBjp7qJzXFdnTVqiJm31rCItaIW1Ywa14WQYaygwSezN8nKBnyHsfB7UemnrIoevo+oe4W3R7XYH+/XQrx0UxtbFzgEr28H+/nBSK5Sr1e/L9/jM4mqac3StkMSKilijOuqrjOVQQOl3z0WunZu7nBD0fWTOpVSRVqy55dTbRcXSOaygdoysnmt0uKhq5rJVana7SXQmCgsQm8lM4FYums1ruU7LvVsBQeMrFK4nVBiYWbWqr3u1fqnszeLZycvl/XCcJ9jRqk3cbv59XnirrELtE0HJs/ZYvnCYeC5GVxsgDomrDBlQxNnbLR0uVJjceB3pdbRH1fh5iBYurimqhf34kwHL6ILYXlmwNkei+B7ejSS3y8A9y2yoHVle3bAk1VNyYQ2f05qslNKUryoXu7098HbEBQIohorbaSxPA3vCBagnyvnPBpyIJwA4NpVZw+3PWO5Q1hH39xWXl8gVCOuP1tce14dGQ66sr3VfQxuvKi+7DdgR/m0JNGydlmLexchOGN/1UVAvHShp1vE0qCy5nvqzcWMskocb499+IuiW6xBnLJFbe/jsAKN5xoxH2RlIhvzmk615IUAX8AeSrcXNOHwNl5LB9L/vYHifrPLytfAbXV1fsMF9eRq1VyOgzILA7XIH1mFH8/aJFZvPyJGTVnl8dgfq/fZFrW/9+t62846YO6afR4JLej4o7bTRBKVzm0F9tokU+0+nC3LD9SEFIB9fV/prYv/f8pjF4i2yoIJCV1mF7MquroYniOiq1i6EFwIR6TQsnYZrbcFC5+Xb2kna2vNIInokwfOFwtH9RBfPNQ14DihNoPZtHBVP1ec/0YykDf3sm4/GlRJsyQaGd9/5Fao5we8UD8sOu0NgwdIjee2Mw2Dh9i9P6STHHN41bn/WrB3XtbQkuGMOtxrz6stfHGhksWMkNiA0X+IW16fK654bob4ZJant+esamky1m1r6Wq+p94+Lywi1PKl+Wv3+ZyOFA4i5xsYovme3iiIpQvg9sIc1af6ny1Sz1wokHGpXiDVkWOFFV0kGu3xs05VrdFF2QZiPG/e0V7071xbuvLeubujRwnU/3U93WPaDLr13P/un9o2l7pFBb40EGpvoPEAkjcMFmv6zSJJxi5xzVy+gaYFb05bI64ZOVNc/OTpHtNopv7qVM8uQ29OW2u5sN3SrYGoXj5FXNHOumBCv127JCq0BVUXKE64l9XpQti3SALnn/G5mvnvtS1sRQ6WL9zJBa1VVl2zcC/DktM1OzEPL8CxV7N8DdQpOgCCpOaRwCN0/ESOvNWBEh/si7oYBLrjpIJF2fVdPL+ziHWrc2512A15QWxVt4Bsemaxbie6aiIV0LXilPdXSJELqovP9twHePlmrfLeISscUHQDXFkHQ3R1pJdMdMejzO5Zf1duSCJYo5T46L54/lpU63Z5vpZR7wrX0hP9WoqXb2lr6ZN7XpNK4ppOnqtkiC0GeeswC6c5dqVarYjlobOSXUG82voObm4jlomFDGonzew7s/BAjLnP87+Lt39ca7Fa4Eo2rGncTlnoWZoCMb/hwnq2I+nQ79quly7id+o0HRyjwk5mUqc/RUoSlZlrlc5DqOk1kqeCgVo2ZGSa65qdmOOy8GZgoWoXutKhunvx+j8u3SU7Sdl5o+B2VjO4zz2rvNZy1PGfK5rIsBEsx6FXNhGDzpzTvkC8daBmkW3HFe1quhcculiy0XfZH0vX+L6d17iSh+cD8XRduCfcUHQDoHmtMpYyhcK6l72BkWKqYPmbHIDsRbVaBbGbgsR1IeBqMb+vbEyDYVc19bvGDhcLswWMVf2k3zdaFjav3dbOUqQPwUbMGyt9NXMZ8VxzbK+ipmwIdY2vTf3Hkmlsdt8ZLnbE1lRL/e4ejdzdi3BxgFvOjJHQBre0uZWgYRHpLrz+TG+yA4KtxpsjKYnKAC7FMbe0Fb3b1xBP9GshnrimRVDfz64Hsy4bXc1AtkumUoXc4LJW1Swd1N6atsZrYw+Mq1QJpI0sQlv39mos3c/IWA4kMfShPs3EuMEdZKa4HS1qlxFj7zrXvUCHt0IVU9kYQ1NPrHYhUz2QiDsPurC+eKB3U/HTU93E5Ie6iovP9kyeKwpQdAMAMSJvWYhOWrqgS9PKlpiVv/Vn6oB2WHjoI6suDPyp1V2naYqhxiDtgGtq5KA2XgvhzW5Yc/z0sz+2WBrXD7ygrnxNuN9VKwCN7mG5q6UJqoWvJlNhQYF+uL4yitecsVB1iVDnN/13EYALleoaNERXV5+rs3TBpkK4mHWjFGuUj5wkKjO4sD77f61kv91gt7jUZdCiyYx6TsATY0wTM7BzpercywDnefdW1QPKtFfXjFhwqjkGwQLnPZplTLz/PCnasLDxcaAB0E0X1RffPnaBjKnDA+btuCC5TWf9IiygCw+ZPUv39Gwk36soh1Ioug7GdX21dAwUrNzUAnJYg0ZvUyT63Pr6XHHhEz+Ll6ascjfQQGH878q0j9OF//GWVaU/LQd1mctnKTFIbyB+gy+Dimqtml3McOGiuYSZ1OR49yxijBdThRwuZp2LurVSc6mWDaHlnc5SUb/4a3Yc1bf6Sy1hmRiluphhnaCZii7ejHguBsur/09hkql01pCuYQkJDCzY1IUwFq5q5jKERG2uocvUxSLYPHlMpU8H765yX2sMddh8qMQX7ul37+0kR5vOePZSaX3WszFYLlGsUTUhytuiB9cEO7d9UYWiGyC6eF2wLF1wqVJbCLcm+svCjfrgB4vEgnUH5Op3wvQNcjQXeOvHNZbXGXTB6diMRXT9sKbUzGXESFG7Fwg3dWvgkWyBeAtqA5uZsp+BIZpfzdtqsViR5GEkmiHmjQ47ZjBd5BUl4QlNFOorX0rV0sUMY1VIcWFVLWQjFqsKNCxV1Q13tqaue+mmg+J7JRkOpSTwoOACrbp/CyO6usYYusb/JDB09aII0ajnj65/ss5LZmflmt2x3kQF7lS7uCVyUHzVMgcbuI99uai7tawiHuzdVLSsU0bmgAy5vLHttmreSIeGFYvVAA/A0X4BoruYBlN0z2tSUQqAOUnjl792SdExJ+cYU0Fgzc5audfy5TOsyjo2/WO9ZSiq7mV/47mq1YjYG7IJT5zKFxe1OD0IG83gzYXzsLzhYn73V2s5zsCunkkdaGmH9pzemrdjFa1+KVUXFboIzVeST/A/ot8vsi8N0HkKx8qciayL3QF0S8L/bI4Rj/t5nSU2bo7b47Mxex4Kk8Gs9lyGi8+fLFTiG8QWzQsvlLOpyX7mzGXzYg+1/uYwhl081wCCBWsX3c10XN2xlkzk+u5Pz3CSEcsNtFlPOIiNjZG1wPjxBRbe89fsk/X9yBW5t5fVg1bUoaUbILBG1OzXYCVSAYioOqUEQqOWsBig3EUFST7Gl0+XAWiuNfSn/WMgrmX1y4WWcd1bV3O3lOusmcBy+5vzLb2Hr+tcx+KGQz9db4tcfFZIClHRZXKq800bVk+3iCmSqWBNqw1HdFYNBE6Ne69W4rnY98vb/puhqi6IYEH5W0cdidOFiirqd0gVXLtzAt/BbkpZi12pjRmcI7oJQXgPWN06FzQ8SWr1QyRQLrWE+Gjo+WLOC91lnbFd5ndRhqIbILokmWBaukBtX2fOpPXHHd7RNC1Fl7DjLa6Lfslq+0d/k6j8oWmN0hZXtTqoAJ1mbrjQugpGLFWN15qtWQzj1rnBdV2pdHFWnQWLto6WbTXbAbVLj0qHRhU9SiPUCwjqj6cXcFrKNiXzmaLrHGoikAo8HGdV1Z8TD1zZVFqncJM+enVz7dg/3Xl+odLf2MhuNpKlVJG/p2fjYmHlFgQcX1xr1Zh5caF47nURjOui8D3QYQf+0rlJpQLXmw3u4eliQlafmrDjLYNZl2BUEPeyN+vX24ocu/6//2tlG0PWTU1BHPeduzvYZjDq+i+rNKqeJi0a9birnbHg9rYbl+ermYpah1m/qnXVjpGBcKcBuKqRiIUmKYeP2U8hwj7uPJQV8TW64QKC+fg1zW0z8rGwtWubCG/N09edLSb9p7N0lforjH07evY+xlsb+R54jdE3t5HXCeQIoGzKHzEn4YFBHodEFyuvYK0s4ars3LSi+PVvvdWDrEhMOFHrclEvpyZSYHWI0WXm6SjeanXVbFssLuo67NI5v2ll2bTdrvbP3FpSt9p/44c17jgZFj5v33mubXmGkfGoxsnVCxqejxV1g6qpMn5kB5qE2CVyeEu6wz6o1gusfiTOmOcAI3FuyPg/xVXn1pRWrxEThvWPY9Pn3JqW804XYkApB3GO686vK2P+GNaBKgIzuN9p4K3COWB4Wgb3bOSxqERm+tt3nev4+xLnoaVbAFACo65yg+VaNrjkbOtILoPnb2gt27WpDDbFcs3Urpjqd5asOiIMQuJ0/170ndZZDZi2pCZP6Vxvr9/eXl6UsLr/8P7zbN3/Bjgm3uYYI05mNLpoVN37BVQXuzNPsVGHPhhc1qq6xRrCfiGjW+3Gg8XBJ7M3eyRhoab5qU/+FveMWyizrw3+XLffMhQCx7e5j25qJHBwnn35cFePEhcs1K7uZD+Rp6Dg3Bhx/Tli2pMXiekjLhF3XOp/wwtStKDoFgBcLNU4nq6DipN0aVZJ27sV6fbYl7u7N/ToPYrhCeYm52bUjElYurqh6ahfVWfgqtOPnABlQKo7DBeyh/s09+v5GGaAQREY04YBEv7grS2euQ8y3MzesIvnGhdKO2sXHZTs+t++d09Hv0uykKne+38zxI9LdsoyMlj9usUXCQ5wF79+ezvxxh3t5Xfwo/90Fq3q+u5zXFBg0frb0pEUTeheLiCIx5lLXS7wUtDtlIsZvUXVxJq7ujd0t28bfVNbsXrHEREfGyuTnezc3WoyFSyp/qNmyfaKZtHSTfYJVnebh/s2l92n0OMZGZ2PXdPCdr6nE6jD7O2E1Jsl68/jEF1kPKvH39vEKlja797TUdz02ly/BnHjuA2bsFh89kc5sVQZ6YZSMW9ublJ48D3DItFbUwdCDCi6BQRF3Dm5LrFw/X45qxIt6IINpvbMWLHbHbu9sl0N9+ABgNhis5q+3Yi6izDiUgPHzJEuLJT0gEXrPd2USCpC/+lggDmlaB8XKiql+ye6iO1C+3WVO3CJ++qGo3N1925vjcOq4H2RDDb4nQXuXs1opHBF+xqyZeXUM2PczKiDHoxEOkJI0YGiW9ADFxcrp8oYk2VCAaxMzN6dtmSHqFc5Tdx+SYMCvQ6EAtNExny32lKqA4sJNYHoZ/unYukiGzdS5rGqQw/sSqJk68xKpcSmPda4d70qp8cbegND05HtjRmoRhjCbli4Lnfgh/9eJBZtOChHnZm9F6hRHvH5MkvXLjPIZm3ho2yJEBJaKLrFDIihE5Mzbrm4gazdfPyjpZYs3lHfrJRuU7XBQjDiueHCrlYXiU8YV6jGeHWi68u1bCzO0Inrvd/Wy6YaSA5TX98baPKuc1viHGhVr5x4dvIy26z2u2nlElLkoOhGMWi6gfrNIeMXesy4xe/PfL7Msn2oppWEgko2tbrqMHl5X/V0MW3JzoCSqNQY7TMDzhFOg2QreD5+WrpLPPfFco/474UtKgctFEAIKTiR4SskBQbCMfG+8yxt5tRB2KhrbVbL+frDcGGXSIX2j/6Ka2Mf5UShAO5mxOCnPHaB6Nuhliw3Qkb7c//XKty7RgjRQEuXiCplS4or29UUX83f6rULT3Ftu2ZnJeoSpLSWrk2vaSfbYRYWuKyHDzg73LtBCPFB5FxFSaG45eL6XocHRFI814i1Yli2iq4uF8lPagwYbnmM5COEkECg6BJ30b3RQF1HJMVzDdSuVHCh2w16V8usWPtKCCkIFF3i5lZNK0mjqX8TZdh8JFCtnOcQgLOqne63rANtNo2RjshwRvY3IYQECmO6xA3qSS9oXln8vmKPx1FBW7tIiucaoIH8T0v/zUr21uAEyVRT/3uRnD2MEXxoXUkIIYFC0SUe3HZJA4voRqJr2WiR+MGQTmLhuv1y9m1nH+PQ0ksmstkEIaRQUHSJB+hg1KttdfH9mTaD6SUTRJ8ONSP2KGFBEamLCkJI0YOiSyyMGHCOdCnvy8gWV7SrIcqUCu4EJUIIiRZiXJgHFgVUr15d3u7YYW0UTwghhISCyMuOIYQQQoooFF1CCCEkRFB0CSGEkBBB0SWEEEJCBEWXEEIICREUXUIIISREUHQJIYSQEEHRJYQQQkIERZcQQggJEVHTkSoxMVHk5eWJKlWqhHtXCCGEFAMqV64sFi9e7OhrRk3v5YQEZ0ax7d69W95SvEkkwfOaRCq7i9g1O2osXadgD2cSifC8JpFK9SLWd58xXUIIISREUHQJIYSQEEHRJYQQQkIERZcQQggJERRdQgghJERQdAkhhJAQwZIhQgghJETQ0iWEEEJCBEWXEEIICREUXUIIISREUHQJIYSQEEHRJYQQQkIERZcQQggJERRdQgghJEREveiuX79e3HzzzaJGjRpy0H21atXEgAEDbAcX33jjjSImJkbcc889fh3gCRMmyO2bNWvm8EdHohHjfAr05+mnn/Z4nRkzZshzuV69eiIlJUWkpqaK+vXrixtuuEFMmzbNr+/NAw88IFq0aCFKly4tkpKS5HeoV69eYty4ceLUqVNBPAok2liyZIno16+fHCpfokQJUatWLXH77beLdevWWbbt2rWrPOdfeuklv14b3w1sj3M3FETNEHsdENYuXbqIrKwseeFp2rSp2LVrl/j000/F5MmTxRtvvCHuvPPOcO8mIW4qVaokOnXqpBXBffv2ibS0NNG8eXPL4zVr1pS3eXl5cpH54Ycful+vSZMmIjs7W2zdulVMmjRJ/vTo0UN8+eWXIjk52fJab775phg6dKgUVog1hDs2NlY+/4cffpA/uOBBvCHkhBSG7777TvTt21fk5ubKBR6u01u2bBHjx48XH330kfj888/F5ZdfXnwOsitKyczMdFWrVs2FQzBgwADX0aNH5f35+fmu1157Td4fFxfnWrlypcfzBg0aJB8bPHiwX+/zwQcfyO2bNm0alP+DEPN52aVLF68H5PHHH5fb1apVyzV37lyPx/Ly8lwff/yxq2zZsnKb6667zvL8X375xRUTE+NKTEx0ffjhh66cnByPx/GaLVu2lM+vW7euKzs7mx8QKTBbt251paamyvPpgQcecJ08eVLef+rUKdfDDz8s7y9VqpRr//797ufgO4D7R40a5dd7PPXUU3L7nj17huSTio3m1dPOnTtF7dq1xfvvvy9X7ABuhnvvvVeu9GEVfPDBB+HeVUIcAR6dV199Vf7+2WefiY4dO3o8DmsVoRXjnMc2a9as8djm+eefx0JdDB8+XAwcOFDEx3s6y/CaU6dOlRb3pk2bxMSJE/npkQLz0UcficzMTNGhQwcxatQoGQIECQkJ8lxE2O7YsWPyXC0uRK3oQmRxgbn77rtljEDFcNFt27YtDHtHiPOsXbtWXqAgrm3atLHdDq46uJ0hrn/++acltgbat29v+3zEdi+99FL5+8KFCx3bfxJ9VKtWTVxzzTXirrvukgaRGfwNV3Nxu05HrejiwvLxxx+LYcOGaR83Eqn8jUkdP35cnHfeefJEaNiwoYwNq+zfv1/ccccdokqVKjLxBCfMiBEj5HMJCTawDkB+fr746aefbLfDOTxr1iwZJ8YFT/caiNt6Y8yYMWL16tXi5ZdfdmTfSXQyaNAgmV8Dr4oKPJF//fWX39dp5Dw0atRInt/Ii4AFrbJ582Zx3XXXifLly8s8n9atW4vXXntN5OTkOPQfRXFM1469e/e67r33XunjL126tIwp+IrpIm514YUXyvsbNmzo2rVrlyWmi/gxYlz4vUGDBq4WLVrI2JgR7zXHJAgJRkwX8dcaNWrI7VJSUlyPPPKIJWfBF4jz4vk4d5EL8fvvv7tyc3P5gZGQsnnzZte1114rz8WaNWvKHB1vMd0DBw64mjdvLu/v2LGjO4fHHNNt3Lixq1y5cvLcxjW5UaNG8n78dO3a1bH8BIruGSZNmiQPckJCgjzITZo0cS1atMhywFTRRWC/e/fuWsE1i64h4r/++qv7MVzw6tSpIx/r37+/Ix8oiU78TaSaOnWqTBA0zkn8VK1aVQro2LFjXRs2bPB5satYsaLH89PS0lw9evRwvfDCC/I7g2REQoLBiy++6Kpfv74rNjbWLaDr16/32EYV3SNHjrhatWol7+vUqZOH4JpFFz9YlC5dutT92OzZs92JhVikOgFF9wyGdWv8VKhQwTVixAjLBcQsurAcevfubSu4quh++umnlsf//PNP+RhOoi1btjjyoZLow1/RBTNnzpTnq/l8N/8g+/irr76yfT7O08suu8z2+RDx559/XmaYEuIkl19+uce5Biv37bffthVdWMDnnnuuW3DNFrFOdOfPn295fPLkyfIxZFEfO3as0P8DRfcM27dvd2VlZckLysiRI10lSpSQB/q+++7TXtzuuusuaZ0apRG7d+/WHmBDdOG2sHPDwdWMbWBpEBJs0TXKg2bMmCHPb7jSdOJ52223eX2NVatWuZ555hl5MTM8ROafNm3auDIyMviBEsfYsmWLdPOuW7fONWzYMLfFO2bMGIvoDh8+3HX++efL39u1a6cVXLPonn322drHcd0uU6aM3Oann34q9P9A0bXhvffekwc5Pj7eI65rXNySk5PdF5f09HTXjh07vIouYgJ2XH/99VqBJyRYoquyb98+12effSbdzGYBHTdunF/PP378uOvnn3923X///XKBaTwfr0dIsPjvf/8rzzOIomGFGqJrvkbXrl3b1ko1RPfGG2+0fR8sLFVxLygRm72MrDZkE+t+fvzxR5/PR9eecuXKyS4oCxYssDyODj7IUm7ZsqXIyMiQKe3eMOqAvT2GOkpCwkGFChXEtddeKzP6kXVcp04def9bb73l1/NLliwpLrnkEpm1jAxQ1LkDdAs6dOhQUPedRC/Dhg2T2ciHDx8Wq1atslyjUTdevXp12cHq0UcfLRLX6IgVXQjh3LlztT979+4VR44cEUuXLpVlPHYYaehINVeB4M6cOVO89957Ii4uTjYEQPtIO7yVBWFfAVqcERIsUJdet25d2b/ZGzjvn332Wfm7ubctyn9QcoGyN2/gAoUWfUZZx8aNGx3ZfxJ9HDhwQNaK68p7jHOtYsWK2us0yoJ+/vln2c7XaF+K63+4r9ERK7poen3GfW75QaP3iy66SNZgQTTt2LFjh7xFXa1Kt27dZPNtvMaQIUPkfbi1E3E0JrDj77//lrccikCCCRpjwAr1Z6CBcc6jXlE9j7///nvpAfIGLoRYjOpegxB/gXGDRix2deGwPA1Pinqd7t27tyhVqpS48sorxVVXXSXr02+55RZx4sSJgK7RqNE1rGgnrtERK7q+gGgCtLzTXUC+/vpr2SYSDd8vvPBCr6+FBheYeoFVmSHAKnit3377zXI/rOV//vlHtjczuvgQEgz69+/vPrfR/MIbaEgALrvsMvd9aDqPto9o/DJy5Eivz//qq6+klQvLGK1WCSnMdXr8Gc+JytixY6UoVq1aVZxzzjm2rwNrF61JIaxoYaoDYUSd8CLkcvToUbmQ9NaJzW9cUcrOnTvdjbSR7IFaLoPvvvtOJkfhMWRn+jPwYNq0ae6g/bfffqstGapSpYpH7S/KhXAfHkMCCiHBTKRCFmbnzp3ldiVLlnT973//szRl2bNnj2vIkCFyG9Qnoi7XzGOPPeY+n2+66SbX2rVrLQlVKOHA66PJwJQpU/ihkgLz119/uevKhw4d6m5QgVJOJLti8AYew/ANXwMP3nzzTXdy7JIlS7QlQ2iQYa77xXXd0IlXXnnFkU8yakUXINsSEyqMTDekjKPuy/gAbr31Vq91uipGhxTUKRoibohu+/bt3VONUKKB5hvG+6C5xokTJ0L2f5PozV7GeYlGFsa5hwsaOqShpAK3Rpc0NAmYN2+e9jXQJAAXLuM1qlev7mrbtq2rWbNm7lI7fJ/8zXwmxBsTJkxwZ9RDAFu3bu2qXLmy/BvnK0qDzNiJLq7laKZh1KIbdeSG6Hbr1k2+Pr4TeBxNOIxz/JZbbnGs6UvUupcBsi0RT7311ltl3Al+ewTT4VLDFCK4NNQm297ABJcyZcpI9xsGfJtB/BfN36+//nqxZ88eOYEF7hAE95GEpRu6QIjTpKeny/jYL7/8IoeAI2aGmBiy/eFCQ3Y/EqaQwYzJLjow3WXZsmXikUceEW3btpXhGfyNEArcycgSxXfptttu4wdIHOm//Oeff8rwCPoh41yDwdinTx8xe/Zs8eSTT/r1OriWjxs3TvYPx2uoIRL0wsc1umfPnjL3AddxZD9/8skn4t133w1IC7zuB5TXkVcihBBCiFei2tIlhBBCQglFlxBCCAkRFF1CCCEkRFB0CSGEkBBB0SWEEEJCBEWXEEIICREUXUIIISREUHQJIYSQEEHRJYQQQkIERZcQQggJERRdQgghJERQdAkhhJAQQdElhBBCQgRFlxBCCAkRFF1CCCEkRFB0CSGEkBBB0SWEEEJCBEWXEEIICREUXUIIISREUHQJIYQQERr+H583Wyy/urJxAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 256x208 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "image/png": {
-       "height": 205,
-       "width": 238
-      }
-     },
-     "output_type": "display_data"
     },
     {
      "data": {
@@ -1254,14 +1221,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 13,
    "id": "f438aa93",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T13:09:27.381888Z",
-     "iopub.status.busy": "2026-04-23T13:09:27.381726Z",
-     "iopub.status.idle": "2026-04-23T13:09:27.384152Z",
-     "shell.execute_reply": "2026-04-23T13:09:27.383759Z"
+     "iopub.execute_input": "2026-04-25T21:49:40.308824Z",
+     "iopub.status.busy": "2026-04-25T21:49:40.308659Z",
+     "iopub.status.idle": "2026-04-25T21:49:40.311106Z",
+     "shell.execute_reply": "2026-04-25T21:49:40.310736Z"
     }
    },
    "outputs": [],

--- a/epione_guide/tutorials/bulk/t_upstream_cutrun.ipynb
+++ b/epione_guide/tutorials/bulk/t_upstream_cutrun.ipynb
@@ -57,34 +57,22 @@
    "id": "504216f4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:26.473156Z",
-     "iopub.status.busy": "2026-04-23T12:52:26.473062Z",
-     "iopub.status.idle": "2026-04-23T12:52:29.901070Z",
-     "shell.execute_reply": "2026-04-23T12:52:29.900463Z"
+     "iopub.execute_input": "2026-04-25T21:37:56.880661Z",
+     "iopub.status.busy": "2026-04-25T21:37:56.880570Z",
+     "iopub.status.idle": "2026-04-25T21:38:00.421084Z",
+     "shell.execute_reply": "2026-04-25T21:38:00.420505Z"
     }
    },
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.merge_pairs' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.make_seqtab' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/omicverse/omicverse/_registry.py:241: UserWarning: Function 'omicverse.alignment.dada2.remove_chimeras' is missing a docstring; agent help output may be limited.\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 \ud83d\udd2c Starting plot initialization...\n",
-      "  \u251c\u2500 Apply Scanpy/matplotlib settings\n",
-      "  \u251c\u2500 Custom font setup\n",
-      "  \u251c\u2500 Suppress warnings\n",
-      "  \u251c\u2500 \n",
+      "└─ 🔬 Starting plot initialization...\n",
+      "  ├─ Apply Scanpy/matplotlib settings\n",
+      "  ├─ Custom font setup\n",
+      "  ├─ Suppress warnings\n",
+      "  ├─ \n",
       "___________      .__                      \n",
       "\\_   _____/_____ |__| ____   ____   ____  \n",
       " |    __)_\\____ \\|  |/  _ \\ /    \\_/ __ \\ \n",
@@ -92,8 +80,8 @@
       "/_______  /   __/|__|\\____/|___|  /\\___  >\n",
       "        \\/|__|                  \\/     \\/ \n",
       "\n",
-      "  \u251c\u2500 \ud83d\udd16 Version: 0.0.1rc1   \ud83d\udcda Tutorials: https://epione.readthedocs.io/\n",
-      "\u2514\u2500 \u2705 plot_set complete.\n",
+      "  ├─ 🔖 Version: 0.0.1rc1   📚 Tutorials: https://epione.readthedocs.io/\n",
+      "└─ ✅ plot_set complete.\n",
       "\n"
      ]
     }
@@ -162,10 +150,10 @@
    "id": "e4919be6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:29.903161Z",
-     "iopub.status.busy": "2026-04-23T12:52:29.902597Z",
-     "iopub.status.idle": "2026-04-23T12:52:29.906799Z",
-     "shell.execute_reply": "2026-04-23T12:52:29.906526Z"
+     "iopub.execute_input": "2026-04-25T21:38:00.423140Z",
+     "iopub.status.busy": "2026-04-25T21:38:00.422740Z",
+     "iopub.status.idle": "2026-04-25T21:38:00.429250Z",
+     "shell.execute_reply": "2026-04-25T21:38:00.428811Z"
     }
    },
    "outputs": [
@@ -173,10 +161,10 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  \u2713  bowtie2                    /scratch/users/steorra/env/omicdev/bin/bowtie2\n",
-      "  \u2713  samtools                   /scratch/users/steorra/env/omicdev/bin/samtools\n",
-      "  \u2713  bedtools                   /scratch/users/steorra/env/omicdev/bin/bedtools\n",
-      "  \u2713  macs2                      /scratch/users/steorra/env/omicdev/bin/macs2\n"
+      "  ✓  bowtie2                    /scratch/users/steorra/env/omicdev/bin/bowtie2\n",
+      "  ✓  samtools                   /scratch/users/steorra/env/omicdev/bin/samtools\n",
+      "  ✓  bedtools                   /scratch/users/steorra/env/omicdev/bin/bedtools\n",
+      "  ✓  macs2                      /scratch/users/steorra/env/omicdev/bin/macs2\n"
      ]
     },
     {
@@ -225,10 +213,10 @@
    "id": "4e461e35",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:29.908391Z",
-     "iopub.status.busy": "2026-04-23T12:52:29.908215Z",
-     "iopub.status.idle": "2026-04-23T12:52:29.917414Z",
-     "shell.execute_reply": "2026-04-23T12:52:29.916863Z"
+     "iopub.execute_input": "2026-04-25T21:38:00.430337Z",
+     "iopub.status.busy": "2026-04-25T21:38:00.430242Z",
+     "iopub.status.idle": "2026-04-25T21:38:21.319859Z",
+     "shell.execute_reply": "2026-04-25T21:38:21.319322Z"
     }
    },
    "outputs": [
@@ -236,51 +224,32 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "skip existing: Rep1_R1.fastq\n",
-      "skip existing: Rep1_R2.fastq\n",
-      "skip existing: Rep2_R1.fastq\n",
-      "skip existing: Rep2_R2.fastq\n"
+      "downloading Rep1_R1.fastq ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "downloading Rep1_R2.fastq ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "downloading Rep2_R1.fastq ...\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "downloading Rep2_R2.fastq ...\n"
      ]
     },
     {
      "data": {
-      "application/vnd.omicverse.dataframe+json": {
-       "dtypes": {
-        "fq1": "object",
-        "fq2": "object",
-        "sample": "object"
-       },
-       "name": null,
-       "ref": "obj:7fade9b13490",
-       "shape": [
-        2,
-        3
-       ],
-       "table": {
-        "columns": [
-         "sample",
-         "fq1",
-         "fq2"
-        ],
-        "data": [
-         [
-          "Rep1",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/fastq/Rep1_R1.fastq",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/fastq/Rep1_R2.fastq"
-         ],
-         [
-          "Rep2",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/fastq/Rep2_R1.fastq",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/fastq/Rep2_R2.fastq"
-         ]
-        ],
-        "index": [
-         "0",
-         "1"
-        ]
-       },
-       "type": "dataframe"
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -377,10 +346,10 @@
    "id": "b79f4899",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:29.918495Z",
-     "iopub.status.busy": "2026-04-23T12:52:29.918397Z",
-     "iopub.status.idle": "2026-04-23T12:52:29.928366Z",
-     "shell.execute_reply": "2026-04-23T12:52:29.927814Z"
+     "iopub.execute_input": "2026-04-25T21:38:21.321206Z",
+     "iopub.status.busy": "2026-04-25T21:38:21.321038Z",
+     "iopub.status.idle": "2026-04-25T21:38:51.560306Z",
+     "shell.execute_reply": "2026-04-25T21:38:51.559667Z"
     }
    },
    "outputs": [
@@ -388,17 +357,844 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 3.17 ms, sys: 910 \u03bcs, total: 4.08 ms\n",
-      "Wall time: 6.05 ms\n"
+      "Settings:\n",
+      "  Output files: \"/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.*.bt2\"\n",
+      "  Line rate: 6 (line is 64 bytes)\n",
+      "  Lines per side: 1 (side is 64 bytes)\n",
+      "  Offset rate: 4 (one in 16)\n",
+      "  FTable chars: 10\n",
+      "  Strings: unpacked\n",
+      "  Max bucket size: default\n",
+      "  Max bucket size, sqrt multiplier: default\n",
+      "  Max bucket size, len divisor: 4\n",
+      "  Difference-cover sample period: 1024\n",
+      "  Endianness: little\n",
+      "  Actual local endianness: little\n",
+      "  Sanity checking: disabled\n",
+      "  Assertions: disabled\n",
+      "  Random seed: 0\n",
+      "  Sizeofs: void*:8, int:4, long:8, size_t:8\n",
+      "Input files DNA, FASTA:\n",
+      "  /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.fa\n",
+      "Reading reference sizes\n",
+      "  Time reading reference sizes: 00:00:01\n",
+      "Calculating joined length\n",
+      "Writing header\n",
+      "Reserving space for joined string\n",
+      "Joining reference sequences\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Building a SMALL index\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Time to join reference sequences: 00:00:00\n",
+      "bmax according to bmaxDivN setting: 9789944\n",
+      "Using parameters --bmax 7342458 --dcv 1024\n",
+      "  Doing ahead-of-time memory usage test\n",
+      "  Passed!  Constructing with these parameters: --bmax 7342458 --dcv 1024\n",
+      "Constructing suffix-array element generator\n",
+      "Building DifferenceCoverSample\n",
+      "  Building sPrime\n",
+      "  Building sPrimeOrder\n",
+      "  V-Sorting samples\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  V-Sorting samples time: 00:00:00\n",
+      "  Allocating rank array\n",
+      "  Ranking v-sort output\n",
+      "  Ranking v-sort output time: 00:00:00\n",
+      "  Invoking Larsson-Sadakane on ranks\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Invoking Larsson-Sadakane on ranks time: 00:00:00\n",
+      "  Sanity-checking and returning\n",
+      "Building samples\n",
+      "Reserving space for 12 sample suffixes\n",
+      "Generating random suffixes\n",
+      "QSorting 12 sample offsets, eliminating duplicates\n",
+      "QSorting sample offsets, eliminating duplicates time: 00:00:00\n",
+      "Multikey QSorting 12 samples\n",
+      "  (Using difference cover)\n",
+      "  Multikey QSorting samples time: 00:00:00\n",
+      "Calculating bucket sizes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Splitting and merging\n",
+      "  Splitting and merging time: 00:00:00\n",
+      "Avg bucket size: 4.89497e+06 (target: 7342457)\n",
+      "Converting suffix-array elements to index image\n",
+      "Allocating ftab, absorbFtab\n",
+      "Entering Ebwt loop\n",
+      "Getting block 1 of 8\n",
+      "  Reserving size (7342458) for bucket 1\n",
+      "  Calculating Z arrays for bucket 1\n",
+      "  Entering block accumulator loop for bucket 1:\n",
+      "  bucket 1: 10%\n",
+      "  bucket 1: 20%\n",
+      "  bucket 1: 30%\n",
+      "  bucket 1: 40%\n",
+      "  bucket 1: 50%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 1: 60%\n",
+      "  bucket 1: 70%\n",
+      "  bucket 1: 80%\n",
+      "  bucket 1: 90%\n",
+      "  bucket 1: 100%\n",
+      "  Sorting block of length 6109124 for bucket 1\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6109125 for bucket 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 2 of 8\n",
+      "  Reserving size (7342458) for bucket 2\n",
+      "  Calculating Z arrays for bucket 2\n",
+      "  Entering block accumulator loop for bucket 2:\n",
+      "  bucket 2: 10%\n",
+      "  bucket 2: 20%\n",
+      "  bucket 2: 30%\n",
+      "  bucket 2: 40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 2: 50%\n",
+      "  bucket 2: 60%\n",
+      "  bucket 2: 70%\n",
+      "  bucket 2: 80%\n",
+      "  bucket 2: 90%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 2: 100%\n",
+      "  Sorting block of length 4162165 for bucket 2\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 4162166 for bucket 2\n",
+      "Getting block 3 of 8\n",
+      "  Reserving size (7342458) for bucket 3\n",
+      "  Calculating Z arrays for bucket 3\n",
+      "  Entering block accumulator loop for bucket 3:\n",
+      "  bucket 3: 10%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 3: 20%\n",
+      "  bucket 3: 30%\n",
+      "  bucket 3: 40%\n",
+      "  bucket 3: 50%\n",
+      "  bucket 3: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 3: 70%\n",
+      "  bucket 3: 80%\n",
+      "  bucket 3: 90%\n",
+      "  bucket 3: 100%\n",
+      "  Sorting block of length 3242487 for bucket 3\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 3242488 for bucket 3\n",
+      "Getting block 4 of 8\n",
+      "  Reserving size (7342458) for bucket 4\n",
+      "  Calculating Z arrays for bucket 4\n",
+      "  Entering block accumulator loop for bucket 4:\n",
+      "  bucket 4: 10%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 20%\n",
+      "  bucket 4: 30%\n",
+      "  bucket 4: 40%\n",
+      "  bucket 4: 50%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 60%\n",
+      "  bucket 4: 70%\n",
+      "  bucket 4: 80%\n",
+      "  bucket 4: 90%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 100%\n",
+      "  Sorting block of length 5059508 for bucket 4\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 5059509 for bucket 4\n",
+      "Getting block 5 of 8\n",
+      "  Reserving size (7342458) for bucket 5\n",
+      "  Calculating Z arrays for bucket 5\n",
+      "  Entering block accumulator loop for bucket 5:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 10%\n",
+      "  bucket 5: 20%\n",
+      "  bucket 5: 30%\n",
+      "  bucket 5: 40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 50%\n",
+      "  bucket 5: 60%\n",
+      "  bucket 5: 70%\n",
+      "  bucket 5: 80%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 90%\n",
+      "  bucket 5: 100%\n",
+      "  Sorting block of length 2717729 for bucket 5\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:00\n",
+      "Returning block of 2717730 for bucket 5\n",
+      "Getting block 6 of 8\n",
+      "  Reserving size (7342458) for bucket 6\n",
+      "  Calculating Z arrays for bucket 6\n",
+      "  Entering block accumulator loop for bucket 6:\n",
+      "  bucket 6: 10%\n",
+      "  bucket 6: 20%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 30%\n",
+      "  bucket 6: 40%\n",
+      "  bucket 6: 50%\n",
+      "  bucket 6: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 70%\n",
+      "  bucket 6: 80%\n",
+      "  bucket 6: 90%\n",
+      "  bucket 6: 100%\n",
+      "  Sorting block of length 6052533 for bucket 6\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6052534 for bucket 6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 7 of 8\n",
+      "  Reserving size (7342458) for bucket 7\n",
+      "  Calculating Z arrays for bucket 7\n",
+      "  Entering block accumulator loop for bucket 7:\n",
+      "  bucket 7: 10%\n",
+      "  bucket 7: 20%\n",
+      "  bucket 7: 30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 7: 40%\n",
+      "  bucket 7: 50%\n",
+      "  bucket 7: 60%\n",
+      "  bucket 7: 70%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 7: 80%\n",
+      "  bucket 7: 90%\n",
+      "  bucket 7: 100%\n",
+      "  Sorting block of length 6696876 for bucket 7\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:05\n",
+      "Returning block of 6696877 for bucket 7\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 8 of 8\n",
+      "  Reserving size (7342458) for bucket 8\n",
+      "  Calculating Z arrays for bucket 8\n",
+      "  Entering block accumulator loop for bucket 8:\n",
+      "  bucket 8: 10%\n",
+      "  bucket 8: 20%\n",
+      "  bucket 8: 30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 8: 40%\n",
+      "  bucket 8: 50%\n",
+      "  bucket 8: 60%\n",
+      "  bucket 8: 70%\n",
+      "  bucket 8: 80%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 8: 90%\n",
+      "  bucket 8: 100%\n",
+      "  Sorting block of length 5119348 for bucket 8\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:02\n",
+      "Returning block of 5119349 for bucket 8\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Exited Ebwt loop\n",
+      "fchr[A]: 0\n",
+      "fchr[C]: 10382214\n",
+      "fchr[G]: 19542866\n",
+      "fchr[T]: 28789052\n",
+      "fchr[$]: 39159777\n",
+      "Exiting Ebwt::buildToDisk()\n",
+      "Returning from initFromVector\n",
+      "Wrote 17248347 bytes to primary EBWT file: /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.1.bt2.tmp\n",
+      "Wrote 9789952 bytes to secondary EBWT file: /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.2.bt2.tmp\n",
+      "Re-opening _in1 and _in2 as input streams\n",
+      "Returning from Ebwt constructor\n",
+      "Headers:\n",
+      "    len: 39159777\n",
+      "    bwtLen: 39159778\n",
+      "    sz: 9789945\n",
+      "    bwtSz: 9789945\n",
+      "    lineRate: 6\n",
+      "    offRate: 4\n",
+      "    offMask: 0xfffffff0\n",
+      "    ftabChars: 10\n",
+      "    eftabLen: 20\n",
+      "    eftabSz: 80\n",
+      "    ftabLen: 1048577\n",
+      "    ftabSz: 4194308\n",
+      "    offsLen: 2447487\n",
+      "    offsSz: 9789948\n",
+      "    lineSz: 64\n",
+      "    sideSz: 64\n",
+      "    sideBwtSz: 48\n",
+      "    sideBwtLen: 192\n",
+      "    numSides: 203958\n",
+      "    numLines: 203958\n",
+      "    ebwtTotLen: 13053312\n",
+      "    ebwtTotSz: 13053312\n",
+      "    color: 0\n",
+      "    reverse: 0\n",
+      "Total time for call to driver() for forward index: 00:00:18\n",
+      "Reading reference sizes\n",
+      "  Time reading reference sizes: 00:00:00\n",
+      "Calculating joined length\n",
+      "Writing header\n",
+      "Reserving space for joined string\n",
+      "Joining reference sequences\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Time to join reference sequences: 00:00:01\n",
+      "  Time to reverse reference sequence: 00:00:00\n",
+      "bmax according to bmaxDivN setting: 9789944\n",
+      "Using parameters --bmax 7342458 --dcv 1024\n",
+      "  Doing ahead-of-time memory usage test\n",
+      "  Passed!  Constructing with these parameters: --bmax 7342458 --dcv 1024\n",
+      "Constructing suffix-array element generator\n",
+      "Building DifferenceCoverSample\n",
+      "  Building sPrime\n",
+      "  Building sPrimeOrder\n",
+      "  V-Sorting samples\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  V-Sorting samples time: 00:00:00\n",
+      "  Allocating rank array\n",
+      "  Ranking v-sort output\n",
+      "  Ranking v-sort output time: 00:00:00\n",
+      "  Invoking Larsson-Sadakane on ranks\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Invoking Larsson-Sadakane on ranks time: 00:00:00\n",
+      "  Sanity-checking and returning\n",
+      "Building samples\n",
+      "Reserving space for 12 sample suffixes\n",
+      "Generating random suffixes\n",
+      "QSorting 12 sample offsets, eliminating duplicates\n",
+      "QSorting sample offsets, eliminating duplicates time: 00:00:00\n",
+      "Multikey QSorting 12 samples\n",
+      "  (Using difference cover)\n",
+      "  Multikey QSorting samples time: 00:00:00\n",
+      "Calculating bucket sizes\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Splitting and merging\n",
+      "  Splitting and merging time: 00:00:00\n",
+      "Avg bucket size: 5.59425e+06 (target: 7342457)\n",
+      "Converting suffix-array elements to index image\n",
+      "Allocating ftab, absorbFtab\n",
+      "Entering Ebwt loop\n",
+      "Getting block 1 of 7\n",
+      "  Reserving size (7342458) for bucket 1\n",
+      "  Calculating Z arrays for bucket 1\n",
+      "  Entering block accumulator loop for bucket 1:\n",
+      "  bucket 1: 10%\n",
+      "  bucket 1: 20%\n",
+      "  bucket 1: 30%\n",
+      "  bucket 1: 40%\n",
+      "  bucket 1: 50%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 1: 60%\n",
+      "  bucket 1: 70%\n",
+      "  bucket 1: 80%\n",
+      "  bucket 1: 90%\n",
+      "  bucket 1: 100%\n",
+      "  Sorting block of length 6882572 for bucket 1\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6882573 for bucket 1\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 2 of 7\n",
+      "  Reserving size (7342458) for bucket 2\n",
+      "  Calculating Z arrays for bucket 2\n",
+      "  Entering block accumulator loop for bucket 2:\n",
+      "  bucket 2: 10%\n",
+      "  bucket 2: 20%\n",
+      "  bucket 2: 30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 2: 40%\n",
+      "  bucket 2: 50%\n",
+      "  bucket 2: 60%\n",
+      "  bucket 2: 70%\n",
+      "  bucket 2: 80%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 2: 90%\n",
+      "  bucket 2: 100%\n",
+      "  Sorting block of length 7217801 for bucket 2\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 7217802 for bucket 2\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 3 of 7\n",
+      "  Reserving size (7342458) for bucket 3\n",
+      "  Calculating Z arrays for bucket 3\n",
+      "  Entering block accumulator loop for bucket 3:\n",
+      "  bucket 3: 10%\n",
+      "  bucket 3: 20%\n",
+      "  bucket 3: 30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 3: 40%\n",
+      "  bucket 3: 50%\n",
+      "  bucket 3: 60%\n",
+      "  bucket 3: 70%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 3: 80%\n",
+      "  bucket 3: 90%\n",
+      "  bucket 3: 100%\n",
+      "  Sorting block of length 6398765 for bucket 3\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6398766 for bucket 3\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 4 of 7\n",
+      "  Reserving size (7342458) for bucket 4\n",
+      "  Calculating Z arrays for bucket 4\n",
+      "  Entering block accumulator loop for bucket 4:\n",
+      "  bucket 4: 10%\n",
+      "  bucket 4: 20%\n",
+      "  bucket 4: 30%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 40%\n",
+      "  bucket 4: 50%\n",
+      "  bucket 4: 60%\n",
+      "  bucket 4: 70%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 4: 80%\n",
+      "  bucket 4: 90%\n",
+      "  bucket 4: 100%\n",
+      "  Sorting block of length 2716193 for bucket 4\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:00\n",
+      "Returning block of 2716194 for bucket 4\n",
+      "Getting block 5 of 7\n",
+      "  Reserving size (7342458) for bucket 5\n",
+      "  Calculating Z arrays for bucket 5\n",
+      "  Entering block accumulator loop for bucket 5:\n",
+      "  bucket 5: 10%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 20%\n",
+      "  bucket 5: 30%\n",
+      "  bucket 5: 40%\n",
+      "  bucket 5: 50%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 5: 60%\n",
+      "  bucket 5: 70%\n",
+      "  bucket 5: 80%\n",
+      "  bucket 5: 90%\n",
+      "  bucket 5: 100%\n",
+      "  Sorting block of length 5106643 for bucket 5\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:00\n",
+      "Returning block of 5106644 for bucket 5\n",
+      "Getting block 6 of 7\n",
+      "  Reserving size (7342458) for bucket 6\n",
+      "  Calculating Z arrays for bucket 6\n",
+      "  Entering block accumulator loop for bucket 6:\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 10%\n",
+      "  bucket 6: 20%\n",
+      "  bucket 6: 30%\n",
+      "  bucket 6: 40%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 50%\n",
+      "  bucket 6: 60%\n",
+      "  bucket 6: 70%\n",
+      "  bucket 6: 80%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 6: 90%\n",
+      "  bucket 6: 100%\n",
+      "  Sorting block of length 6895232 for bucket 6\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 6895233 for bucket 6\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Getting block 7 of 7\n",
+      "  Reserving size (7342458) for bucket 7\n",
+      "  Calculating Z arrays for bucket 7\n",
+      "  Entering block accumulator loop for bucket 7:\n",
+      "  bucket 7: 10%\n",
+      "  bucket 7: 20%\n",
+      "  bucket 7: 30%\n",
+      "  bucket 7: 40%\n",
+      "  bucket 7: 50%\n",
+      "  bucket 7: 60%\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  bucket 7: 70%\n",
+      "  bucket 7: 80%\n",
+      "  bucket 7: 90%\n",
+      "  bucket 7: 100%\n",
+      "  Sorting block of length 3942565 for bucket 7\n",
+      "  (Using difference cover)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  Sorting block time: 00:00:01\n",
+      "Returning block of 3942566 for bucket 7\n",
+      "Exited Ebwt loop\n",
+      "fchr[A]: 0\n",
+      "fchr[C]: 10382214\n",
+      "fchr[G]: 19542866\n",
+      "fchr[T]: 28789052\n",
+      "fchr[$]: 39159777\n",
+      "Exiting Ebwt::buildToDisk()\n",
+      "Returning from initFromVector\n",
+      "Wrote 17248347 bytes to primary EBWT file: /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.rev.1.bt2.tmp\n",
+      "Wrote 9789952 bytes to secondary EBWT file: /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.rev.2.bt2.tmp\n",
+      "Re-opening _in1 and _in2 as input streams\n",
+      "Returning from Ebwt constructor\n",
+      "Headers:\n",
+      "    len: 39159777\n",
+      "    bwtLen: 39159778\n",
+      "    sz: 9789945\n",
+      "    bwtSz: 9789945\n",
+      "    lineRate: 6\n",
+      "    offRate: 4\n",
+      "    offMask: 0xfffffff0\n",
+      "    ftabChars: 10\n",
+      "    eftabLen: 20\n",
+      "    eftabSz: 80\n",
+      "    ftabLen: 1048577\n",
+      "    ftabSz: 4194308\n",
+      "    offsLen: 2447487\n",
+      "    offsSz: 9789948\n",
+      "    lineSz: 64\n",
+      "    sideSz: 64\n",
+      "    sideBwtSz: 48\n",
+      "    sideBwtLen: 192\n",
+      "    numSides: 203958\n",
+      "    numLines: 203958\n",
+      "    ebwtTotLen: 13053312\n",
+      "    ebwtTotSz: 13053312\n",
+      "    color: 0\n",
+      "    reverse: 1\n",
+      "Total time for backward call to driver() for mirror index: 00:00:12\n",
+      "CPU times: user 219 ms, sys: 85.4 ms, total: 305 ms\n",
+      "Wall time: 30.2 s\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.3.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.3.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.4.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.4.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.1.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.1.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.2.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.2.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.rev.1.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.rev.1.bt2\n",
+      "Renaming /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.rev.2.bt2.tmp to /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.rev.2.bt2\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'fasta': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/ref/chr22.fa',\n",
-       " 'fai': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/ref/chr22.fa.fai',\n",
-       " 'chrom_sizes': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/ref/chr22.chrom.sizes',\n",
-       " 'ref_index': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/ref/chr22'}"
+       "{'fasta': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.fa',\n",
+       " 'fai': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.fa.fai',\n",
+       " 'chrom_sizes': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22.chrom.sizes',\n",
+       " 'ref_index': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/chr22'}"
       ]
      },
      "execution_count": 4,
@@ -451,10 +1247,10 @@
    "id": "c3d1dd99",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:29.929465Z",
-     "iopub.status.busy": "2026-04-23T12:52:29.929345Z",
-     "iopub.status.idle": "2026-04-23T12:52:41.494634Z",
-     "shell.execute_reply": "2026-04-23T12:52:41.493748Z"
+     "iopub.execute_input": "2026-04-25T21:38:51.561726Z",
+     "iopub.status.busy": "2026-04-25T21:38:51.561612Z",
+     "iopub.status.idle": "2026-04-25T21:39:03.481912Z",
+     "shell.execute_reply": "2026-04-25T21:39:03.481050Z"
     }
    },
    "outputs": [
@@ -532,45 +1328,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 4.94 s, sys: 117 ms, total: 5.06 s\n",
-      "Wall time: 11.6 s\n"
+      "CPU times: user 5 s, sys: 117 ms, total: 5.12 s\n",
+      "Wall time: 11.9 s\n"
      ]
     },
     {
      "data": {
-      "application/vnd.omicverse.dataframe+json": {
-       "dtypes": {
-        "bam": "object",
-        "bigwig": "object"
-       },
-       "name": null,
-       "ref": "obj:7fade97bc6a0",
-       "shape": [
-        2,
-        2
-       ],
-       "table": {
-        "columns": [
-         "bam",
-         "bigwig"
-        ],
-        "data": [
-         [
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/Rep1/Rep1.filtered.bam",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/Rep1/Rep1.rpkm.bw"
-         ],
-         [
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/Rep2/Rep2.filtered.bam",
-          "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/Rep2/Rep2.rpkm.bw"
-         ]
-        ],
-        "index": [
-         "Rep1",
-         "Rep2"
-        ]
-       },
-       "type": "dataframe"
-      },
       "text/html": [
        "<div>\n",
        "<style scoped>\n",
@@ -699,10 +1462,10 @@
    "id": "3733440f",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:41.496311Z",
-     "iopub.status.busy": "2026-04-23T12:52:41.496152Z",
-     "iopub.status.idle": "2026-04-23T12:52:44.145216Z",
-     "shell.execute_reply": "2026-04-23T12:52:44.144467Z"
+     "iopub.execute_input": "2026-04-25T21:39:03.483724Z",
+     "iopub.status.busy": "2026-04-25T21:39:03.483500Z",
+     "iopub.status.idle": "2026-04-25T21:39:06.088432Z",
+     "shell.execute_reply": "2026-04-25T21:39:06.087871Z"
     }
    },
    "outputs": [
@@ -710,15 +1473,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 2.53 s, sys: 49.7 ms, total: 2.58 s\n",
-      "Wall time: 2.64 s\n"
+      "CPU times: user 2.49 s, sys: 55.7 ms, total: 2.55 s\n",
+      "Wall time: 2.6 s\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'merged_bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/merged/Rep12.filtered.bam',\n",
-       " 'merged_bigwig': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/merged/Rep12.rpkm.bw'}"
+       "{'merged_bam': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/merged/Rep12.filtered.bam',\n",
+       " 'merged_bigwig': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/merged/Rep12.rpkm.bw'}"
       ]
      },
      "execution_count": 6,
@@ -780,10 +1543,10 @@
    "id": "6e2db232",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:44.146587Z",
-     "iopub.status.busy": "2026-04-23T12:52:44.146462Z",
-     "iopub.status.idle": "2026-04-23T12:52:44.278875Z",
-     "shell.execute_reply": "2026-04-23T12:52:44.278373Z"
+     "iopub.execute_input": "2026-04-25T21:39:06.089775Z",
+     "iopub.status.busy": "2026-04-25T21:39:06.089669Z",
+     "iopub.status.idle": "2026-04-25T21:39:06.305843Z",
+     "shell.execute_reply": "2026-04-25T21:39:06.305335Z"
     }
    },
    "outputs": [
@@ -791,20 +1554,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 466 \u03bcs, sys: 1.03 ms, total: 1.49 ms\n",
-      "Wall time: 128 ms\n"
+      "CPU times: user 847 μs, sys: 897 μs, total: 1.74 ms\n",
+      "Wall time: 212 ms\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: \n",
-      "# Command line: callpeak -t /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/merged/Rep12.filtered.bam -f BAMPE -g 50818468 --keep-dup all -q 0.01 -n Rep12 --outdir /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/peaks --nomodel --call-summits\n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: \n",
+      "# Command line: callpeak -t /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/merged/Rep12.filtered.bam -f BAMPE -g 50818468 --keep-dup all -q 0.01 -n Rep12 --outdir /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/peaks --nomodel --call-summits\n",
       "# ARGUMENTS LIST:\n",
       "# name = Rep12\n",
       "# format = BAMPE\n",
-      "# ChIP-seq file = ['/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/merged/Rep12.filtered.bam']\n",
+      "# ChIP-seq file = ['/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/merged/Rep12.filtered.bam']\n",
       "# control file = None\n",
       "# effective genome size = 5.08e+07\n",
       "# band width = 300\n",
@@ -818,31 +1581,31 @@
       "# Paired-End mode is on\n",
       "# Searching for subpeak summits is on\n",
       " \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #1 read fragment files... \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #1 read treatment fragments... \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: 2478 fragments have been read. \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #1 mean fragment size is determined as 67.8 bp from treatment \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #1 fragment size = 67.8 \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #1  total fragments in treatment: 2478 \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #1 finished! \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #2 Build Peak Model... \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #2 Skipped... \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #3 Call peaks... \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #3 Going to call summits inside each peak ... \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #3 Pre-compute pvalue-qvalue table... \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #3 Call peaks for each chromosome... \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #4 Write output xls file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/peaks/Rep12_peaks.xls \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #4 Write peak in narrowPeak format file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/peaks/Rep12_peaks.narrowPeak \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: #4 Write summits bed file... /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/peaks/Rep12_summits.bed \n",
-      "INFO  @ Thu, 23 Apr 2026 05:52:44: Done! \n"
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #1 read fragment files... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #1 read treatment fragments... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: 2478 fragments have been read. \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #1 mean fragment size is determined as 67.8 bp from treatment \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #1 fragment size = 67.8 \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #1  total fragments in treatment: 2478 \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #1 finished! \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #2 Build Peak Model... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #2 Skipped... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #3 Call peaks... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #3 Going to call summits inside each peak ... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #3 Pre-compute pvalue-qvalue table... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #3 Call peaks for each chromosome... \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #4 Write output xls file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/peaks/Rep12_peaks.xls \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #4 Write peak in narrowPeak format file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/peaks/Rep12_peaks.narrowPeak \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: #4 Write summits bed file... /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/peaks/Rep12_summits.bed \n",
+      "INFO  @ Sat, 25 Apr 2026 14:39:06: Done! \n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "{'narrowPeak': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/peaks/Rep12_peaks.narrowPeak',\n",
-       " 'summits': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/peaks/Rep12_summits.bed',\n",
-       " 'xls': '/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/result/peaks/Rep12_peaks.xls'}"
+       "{'narrowPeak': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/peaks/Rep12_peaks.narrowPeak',\n",
+       " 'summits': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/peaks/Rep12_summits.bed',\n",
+       " 'xls': '/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/result/peaks/Rep12_peaks.xls'}"
       ]
      },
      "execution_count": 7,
@@ -902,10 +1665,10 @@
    "id": "26f67311",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:44.280018Z",
-     "iopub.status.busy": "2026-04-23T12:52:44.279916Z",
-     "iopub.status.idle": "2026-04-23T12:52:44.353641Z",
-     "shell.execute_reply": "2026-04-23T12:52:44.353171Z"
+     "iopub.execute_input": "2026-04-25T21:39:06.307038Z",
+     "iopub.status.busy": "2026-04-25T21:39:06.306941Z",
+     "iopub.status.idle": "2026-04-25T21:39:06.383571Z",
+     "shell.execute_reply": "2026-04-25T21:39:06.383091Z"
     }
    },
    "outputs": [
@@ -913,8 +1676,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Load bigWig files\n",
-      "  \u2514\u2500 Loading Rep12 CUT&RUN...\n"
+      "└─ Load bigWig files\n",
+      "  └─ Loading Rep12 CUT&RUN...\n"
      ]
     },
     {
@@ -1010,10 +1773,10 @@
    "id": "ff8e0387",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:44.354739Z",
-     "iopub.status.busy": "2026-04-23T12:52:44.354644Z",
-     "iopub.status.idle": "2026-04-23T12:52:47.499462Z",
-     "shell.execute_reply": "2026-04-23T12:52:47.498876Z"
+     "iopub.execute_input": "2026-04-25T21:39:06.384705Z",
+     "iopub.status.busy": "2026-04-25T21:39:06.384610Z",
+     "iopub.status.idle": "2026-04-25T21:39:09.520836Z",
+     "shell.execute_reply": "2026-04-25T21:39:09.520271Z"
     }
    },
    "outputs": [
@@ -1021,15 +1784,15 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Converting GFF to GTF: /scratch/users/steorra/data/snapatac2_cache/gencode_v41_GRCh38.gff3.gz -> /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/ref/gencode_v41_chr22.transcripts.gtf\n"
+      "└─ Converting GFF to GTF: /scratch/users/steorra/data/snapatac2_cache/gencode_v41_GRCh38.gff3.gz -> /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/gencode_v41_chr22.transcripts.gtf\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Wrote 3939 GTF records\n",
-      "/scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/ref/gencode_v41_chr22.transcripts.gtf 3939\n"
+      "└─ Wrote 3939 GTF records\n",
+      "/scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/gencode_v41_chr22.transcripts.gtf 3939\n"
      ]
     }
    ],
@@ -1058,10 +1821,10 @@
    "id": "48dbdd01",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:47.500699Z",
-     "iopub.status.busy": "2026-04-23T12:52:47.500591Z",
-     "iopub.status.idle": "2026-04-23T12:52:48.226344Z",
-     "shell.execute_reply": "2026-04-23T12:52:48.225829Z"
+     "iopub.execute_input": "2026-04-25T21:39:09.522127Z",
+     "iopub.status.busy": "2026-04-25T21:39:09.522019Z",
+     "iopub.status.idle": "2026-04-25T21:39:10.252908Z",
+     "shell.execute_reply": "2026-04-25T21:39:10.252376Z"
     }
    },
    "outputs": [
@@ -1069,16 +1832,16 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u2514\u2500 Load bigWig files\n",
-      "  \u2514\u2500 Loading Rep12 CUT&RUN...\n",
-      "\u2514\u2500 Load GTF file\n",
-      "  \u251c\u2500 Reading GTF...\n",
-      "  \u2514\u2500 Reading GTF file from /scratch/users/steorra/analysis/omicverse_dev/epione/case/otx2/galaxy_cutrun_demo/ref/gencode_v41_chr22.transcripts.gtf...\n",
-      "  \u2514\u2500 GTF file read successfully\n",
-      "  \u2514\u2500 GTF loaded\n",
-      "\u2514\u2500 Compute matrix: Rep12 CUT&RUN\n",
-      "  \u251c\u2500 Prepare features\n",
-      "  \u251c\u2500 Build matrices\n"
+      "└─ Load bigWig files\n",
+      "  └─ Loading Rep12 CUT&RUN...\n",
+      "└─ Load GTF file\n",
+      "  ├─ Reading GTF...\n",
+      "  └─ Reading GTF file from /scratch/users/steorra/analysis/omicverse_dev/epione/epione_guide/tutorials/bulk/galaxy_cutrun_demo/ref/gencode_v41_chr22.transcripts.gtf...\n",
+      "  └─ GTF file read successfully\n",
+      "  └─ GTF loaded\n",
+      "└─ Compute matrix: Rep12 CUT&RUN\n",
+      "  ├─ Prepare features\n",
+      "  ├─ Build matrices\n"
      ]
     },
     {
@@ -1094,7 +1857,7 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Chromosomes: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1/1 [00:00<00:00,  1.87chr/s]"
+      "Chromosomes: 100%|████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.87chr/s]"
      ]
     },
     {
@@ -1102,18 +1865,18 @@
      "output_type": "stream",
      "text": [
       "\r",
-      "Chromosomes: 100%|\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588\u2588| 1/1 [00:00<00:00,  1.87chr/s]"
+      "Chromosomes: 100%|████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.87chr/s]"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "  \u2514\u2500 Finalize\n",
-      "  \u2514\u2500 Rep12 CUT&RUN matrix finished\n",
-      "  \u2514\u2500 Rep12 CUT&RUN tss matrix in bw_tss_scores_dict[Rep12 CUT&RUN]\n",
-      "  \u2514\u2500 Rep12 CUT&RUN tes matrix in bw_tes_scores_dict[Rep12 CUT&RUN]\n",
-      "  \u2514\u2500 Rep12 CUT&RUN body matrix in bw_body_scores_dict[Rep12 CUT&RUN]\n"
+      "  └─ Finalize\n",
+      "  └─ Rep12 CUT&RUN matrix finished\n",
+      "  └─ Rep12 CUT&RUN tss matrix in bw_tss_scores_dict[Rep12 CUT&RUN]\n",
+      "  └─ Rep12 CUT&RUN tes matrix in bw_tes_scores_dict[Rep12 CUT&RUN]\n",
+      "  └─ Rep12 CUT&RUN body matrix in bw_body_scores_dict[Rep12 CUT&RUN]\n"
      ]
     },
     {
@@ -1210,10 +1973,10 @@
    "id": "4168d4c6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-23T12:52:48.227569Z",
-     "iopub.status.busy": "2026-04-23T12:52:48.227470Z",
-     "iopub.status.idle": "2026-04-23T12:52:48.229849Z",
-     "shell.execute_reply": "2026-04-23T12:52:48.229470Z"
+     "iopub.execute_input": "2026-04-25T21:39:10.254103Z",
+     "iopub.status.busy": "2026-04-25T21:39:10.254003Z",
+     "iopub.status.idle": "2026-04-25T21:39:10.256584Z",
+     "shell.execute_reply": "2026-04-25T21:39:10.256109Z"
     }
    },
    "outputs": [],


### PR DESCRIPTION
## Context
PR 4b said the 3 upstream FASTQ-pipeline tutorials needed "FASTQ + ~10 h". That was true for the canonical full-genome workflows but wrong for the **Galaxy training subsets** these tutorials actually use (each pulls a small chr-restricted FASTQ inline in ~hundreds of MB). Re-executed all three end-to-end on a Sherlock CPU node with bowtie2 / samtools / macs2 from omicdev.

## What re-ran
| Tutorial | PNGs | Notes |
|---|---|---|
| `bulk/t_upstream_atac` | 3 | SRR891268_chr22 enriched (Galaxy ATAC tutorial subset) |
| `bulk/t_upstream_chipseq` | 3 | G1E Tal1 ChIP-seq (Galaxy training); fix below |
| `bulk/t_upstream_cutrun` | 3 | OTX2 day-2 CUT&RUN demo |

## Fix
`t_upstream_chipseq.ipynb` had a stale hardcoded `CHR4_GTF=` cell overriding the dynamically-computed path with a non-existent `case/otx2/galaxy_chipseq_demo/...` location from a previous dev session. The preceding cell already calls `epi.utils.convert_gff_to_gtf` to materialise the GTF properly; removed the override cell so the dynamic path takes effect.

## .gitignore
Added the per-tutorial scratch dirs so multi-GB pipeline outputs aren't accidentally committed:
- `epione_guide/tutorials/**/galaxy_atac_demo/`
- `epione_guide/tutorials/**/galaxy_chipseq_demo/`
- `epione_guide/tutorials/**/galaxy_cutrun_demo/`
- `epione_guide/tutorials/**/heme_footprint/`
- `epione_guide/tutorials/**/label_transfer/`

## Total v0.4 tutorial state (combined with PR 4b)
**16/16 notebooks re-executed cleanly on the v0.4 architecture, 79 PNG outputs, 0 errors.**

## Test plan
- [x] All 3 upstream tutorials end-to-end: download → trim → align → dedup → peak-call → bigwig → metaplot. 0 errors.
- [x] `pytest tests/` — 71/71 pass (no functional changes to package code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)