### PR TITLE
feat: epione.bulk.hic Phase 2B — insulation score + TAD boundaries

### DIFF
--- a/epione/bulk/hic/__init__.py
+++ b/epione/bulk/hic/__init__.py
@@ -1,41 +1,52 @@
 """Bulk Hi-C analysis — companion to :mod:`epione.single.hic`.
 
-Operates on a single deeply-sequenced ``.cool`` / ``.mcool``
-(typically built by :mod:`epione.upstream` from a paired FASTQ via
-the bwa + pairtools + cooler chain). Phase 1 covers ICE balancing;
-Phase 2 (this commit) adds A/B compartments and saddle plots.
+Operates on a single deeply-sequenced ``.cool`` / ``.mcool``. Phase
+1 covers ICE balancing; Phase 2 adds compartments + saddle + the
+pyramid contact view; Phase 2B (this commit) adds insulation score
++ TAD-boundary calling.
 
 Public API (flat — call as ``epi.bulk.hic.X``):
-    * :func:`balance_cool` — ICE-balance a ``.cool`` in place
-    * :func:`compartments` — per-bin A/B eigenvectors via cooltools
-    * :func:`saddle`       — A/B compartmentalisation strength matrix
-    * :func:`plot_contact_matrix`  — log-scale region heatmap
-    * :func:`plot_decay_curve`     — P(s) curve, the canonical QC plot
-    * :func:`plot_coverage`        — per-bin coverage + ICE weight panels
-    * :func:`plot_compartments`    — per-bin E1 track for one chromosome
-    * :func:`plot_saddle`          — compartmentalisation strength heatmap
+    * :func:`balance_cool`            — ICE-balance a ``.cool``
+    * :func:`compartments`            — per-bin A/B eigenvectors
+    * :func:`saddle`                  — compartment-strength matrix
+    * :func:`insulation`              — diamond-insulation score
+    * :func:`tad_boundaries`          — boundary BED from insulation
+    * :func:`plot_contact_matrix`     — region heatmap
+    * :func:`plot_contact_triangle`   — pyramid view of region
+    * :func:`plot_decay_curve`        — P(s) QC plot
+    * :func:`plot_coverage`           — coverage + ICE weight panels
+    * :func:`plot_compartments`       — chromosome E1 track
+    * :func:`plot_saddle`             — A/B saddle heatmap
+    * :func:`plot_insulation`         — insulation score line + boundaries
 """
 from __future__ import annotations
 
 from ._balance import balance_cool
 from ._compartments import compartments, saddle
+from ._insulation import insulation, tad_boundaries
 # Plotting helpers live in :mod:`epione.pl` since v0.4 (PR 3); import
 # them from there so ``epi.bulk.hic.plot_*`` still resolves.
 from epione.pl._contact import (
     plot_contact_matrix,
+    plot_contact_triangle,
     plot_decay_curve,
     plot_coverage,
     plot_compartments,
     plot_saddle,
+    plot_insulation,
 )
 
 __all__ = [
     "balance_cool",
     "compartments",
     "saddle",
+    "insulation",
+    "tad_boundaries",
     "plot_contact_matrix",
+    "plot_contact_triangle",
     "plot_decay_curve",
     "plot_coverage",
     "plot_compartments",
     "plot_saddle",
+    "plot_insulation",
 ]

--- a/epione/bulk/hic/_insulation.py
+++ b/epione/bulk/hic/_insulation.py
@@ -1,0 +1,161 @@
+"""Insulation score and TAD-boundary calling for bulk Hi-C.
+
+Wraps :func:`cooltools.insulation` (the diamond-insulation score
+of Crane et al. 2015 / cooltools 0.7) to score every bin's
+"insulation" — i.e. how much it interrupts surrounding contact
+density. Sliding a diamond-shaped window of size ``window_bp``
+along the diagonal, the score is
+
+    log2 ( median upstream-of-bin / median downstream-of-bin )
+
+normalised; deep dips (negative) mark putative TAD boundaries. The
+companion :func:`tad_boundaries` thresholds the score (Li-method by
+default) to emit a discrete BED of boundaries with confidence
+estimates, matching panel h of Maziak 2026 / Chang 2024.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+
+
+def _resolve_uri(path: Union[str, Path], resolution: Optional[int]) -> str:
+    p = str(path)
+    if "::" in p:
+        return p
+    if resolution is None:
+        return p
+    return f"{p}::resolutions/{int(resolution)}"
+
+
+def insulation(
+    cool_path: Union[str, Path],
+    *,
+    window_bp: Union[int, Sequence[int]] = 100_000,
+    resolution: Optional[int] = None,
+    chromosomes: Optional[Sequence[str]] = None,
+    ignore_diags: Optional[int] = None,
+    threshold: Union[str, float] = "Li",
+    nproc: int = 1,
+) -> pd.DataFrame:
+    """Diamond insulation score per bin from a balanced ``.cool``.
+
+    Arguments:
+        cool_path: ``.cool`` / ``.mcool::resolutions/N`` (must be
+            ICE-balanced; pass through :func:`balance_cool` first).
+        window_bp: diamond-window size in bp. ``100_000`` (100 kb)
+            is the cooltools default for mammalian TADs at 10–25 kb
+            bin resolution. Pass a list to score multiple windows in
+            one shot — useful for picking the right window for an
+            unfamiliar dataset.
+        resolution: bp resolution for ``.mcool``.
+        chromosomes: subset; default = every chromosome in the cool.
+        ignore_diags: number of near-diagonal bins to mask. Default
+            (``None``) lets cooltools pick a sensible value from the
+            cool's metadata.
+        threshold: boundary-strength cutoff method passed through to
+            cooltools. ``'Li'`` (default) is the automated method
+            from Crane et al. 2015; pass a float to set a hard
+            cutoff.
+        nproc: parallel processes for the per-chromosome scoring.
+
+    Returns:
+        ``pandas.DataFrame`` with one row per bin and columns:
+
+        * ``chrom``, ``start``, ``end``: bin coordinates
+        * ``log2_insulation_score_<W>``: insulation score for window
+          ``W`` (one column per requested ``window_bp``)
+        * ``boundary_strength_<W>``: per-bin minimum boundary strength
+        * ``is_boundary_<W>``: bool, ``True`` for thresholded boundaries
+
+        Bins masked by ICE balancing show ``NaN`` insulation scores.
+    """
+    import cooler
+    import cooltools
+
+    clr = cooler.Cooler(_resolve_uri(cool_path, resolution))
+    if chromosomes is not None:
+        view = pd.DataFrame({
+            "chrom": list(chromosomes),
+            "start": [0] * len(chromosomes),
+            "end": [int(clr.chromsizes[c]) for c in chromosomes],
+            "name": list(chromosomes),
+        })
+    else:
+        view = None
+
+    if isinstance(window_bp, (int, np.integer)):
+        window_bp = [int(window_bp)]
+    else:
+        window_bp = [int(w) for w in window_bp]
+
+    df = cooltools.insulation(
+        clr=clr,
+        window_bp=window_bp,
+        view_df=view,
+        ignore_diags=ignore_diags,
+        threshold=threshold,
+        nproc=int(nproc),
+    )
+    return df
+
+
+def tad_boundaries(
+    insulation_df: pd.DataFrame,
+    *,
+    window_bp: Optional[int] = None,
+    min_strength: Optional[float] = None,
+) -> pd.DataFrame:
+    """Extract TAD boundaries from an insulation table.
+
+    Arguments:
+        insulation_df: output of :func:`insulation`.
+        window_bp: which window to use when the insulation table holds
+            multiple. Default = the smallest window present.
+        min_strength: optional override for the boundary-strength
+            threshold; if ``None``, use cooltools' ``is_boundary_<W>``
+            (Li-method auto-threshold).
+
+    Returns:
+        BED-like DataFrame with ``chrom``, ``start``, ``end``,
+        ``window_bp``, ``insulation_score``, ``boundary_strength``,
+        sorted by genomic coordinate.
+    """
+    cols = [c for c in insulation_df.columns
+            if c.startswith("log2_insulation_score_")]
+    if not cols:
+        raise KeyError(
+            "insulation_df has no log2_insulation_score_* column — "
+            "did the cooler have weight column for ICE balancing?"
+        )
+    avail = [int(c.rsplit("_", 1)[-1]) for c in cols]
+    if window_bp is None:
+        window_bp = min(avail)
+    if window_bp not in avail:
+        raise KeyError(
+            f"window_bp={window_bp} not in insulation_df; available: "
+            f"{sorted(avail)}"
+        )
+
+    score_col = f"log2_insulation_score_{window_bp}"
+    strength_col = f"boundary_strength_{window_bp}"
+    is_bnd_col = f"is_boundary_{window_bp}"
+
+    if min_strength is not None:
+        mask = insulation_df[strength_col] >= float(min_strength)
+    else:
+        mask = insulation_df[is_bnd_col].astype(bool)
+
+    out = insulation_df.loc[mask, ["chrom", "start", "end",
+                                   score_col, strength_col]].copy()
+    out = out.rename(columns={
+        score_col: "insulation_score",
+        strength_col: "boundary_strength",
+    })
+    out["window_bp"] = int(window_bp)
+    out = out[["chrom", "start", "end", "window_bp",
+               "insulation_score", "boundary_strength"]]
+    return out.sort_values(["chrom", "start"]).reset_index(drop=True)

--- a/epione/pl/__init__.py
+++ b/epione/pl/__init__.py
@@ -17,6 +17,7 @@ from ._contact import (
     plot_cell_contacts,
     plot_compartments,
     plot_saddle,
+    plot_insulation,
 )
 
 from ._peak2gene import plot_peak2gene
@@ -50,6 +51,7 @@ __all__ = [
     "plot_decay_curve", "plot_coverage",
     "plot_cell_contacts",
     "plot_compartments", "plot_saddle",
+    "plot_insulation",
     "plot_peak2gene",
     "plot_footprints",
     "plot_multi_scale_footprint",

--- a/epione/pl/_contact.py
+++ b/epione/pl/_contact.py
@@ -624,3 +624,95 @@ def plot_contact_triangle(
         fig.colorbar(mesh, ax=ax, shrink=0.7,
                      label="log10(1+contact)" if log else "contact")
     return fig, ax, mesh
+
+
+def plot_insulation(
+    insulation_df,
+    *,
+    chromosome: str,
+    window_bp: Optional[int] = None,
+    region_start: Optional[int] = None,
+    region_end: Optional[int] = None,
+    boundaries: bool = True,
+    boundaries_df=None,
+    figsize: Tuple[float, float] = (8.0, 1.6),
+    color: str = "#3a6eb3",
+    title: Optional[str] = None,
+    ax=None,
+):
+    """Per-bin insulation-score line plot for one chromosome.
+
+    Renders the diamond-insulation score from :func:`epione.bulk.hic.insulation`
+    as a line; optionally drops vertical ticks at the called TAD
+    boundaries (red by default). Designed to stack on top of a
+    contact-pyramid panel in figures of the Maziak 2026 / Chang 2024
+    style.
+
+    Arguments:
+        insulation_df: output of :func:`epione.bulk.hic.insulation`.
+        chromosome: which chrom to plot.
+        window_bp: which insulation window (when the table holds
+            several). Default = smallest available.
+        region_start, region_end: optional zoom in bp.
+        boundaries: draw vertical ticks at boundaries from
+            ``boundaries_df`` (or auto-extract via
+            :func:`epione.bulk.hic.tad_boundaries`).
+        boundaries_df: pre-computed boundary DataFrame; if ``None``
+            and ``boundaries=True``, derive on the fly.
+        figsize, color, title, ax: cosmetic.
+
+    Returns:
+        ``(fig, ax)``.
+    """
+    import matplotlib.pyplot as plt
+
+    cols = [c for c in insulation_df.columns
+            if c.startswith("log2_insulation_score_")]
+    if not cols:
+        raise KeyError(
+            "insulation_df missing log2_insulation_score_* columns"
+        )
+    avail = [int(c.rsplit("_", 1)[-1]) for c in cols]
+    if window_bp is None:
+        window_bp = min(avail)
+    score_col = f"log2_insulation_score_{int(window_bp)}"
+
+    sub = insulation_df.loc[insulation_df["chrom"] == chromosome].copy()
+    if sub.empty:
+        raise KeyError(
+            f"chromosome {chromosome!r} not in insulation_df"
+        )
+    if region_start is not None:
+        sub = sub[sub["end"] > region_start]
+    if region_end is not None:
+        sub = sub[sub["start"] < region_end]
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+
+    centers = (sub["start"] + sub["end"]) / 2 / 1e6
+    ax.plot(centers, sub[score_col], color=color, lw=1.0)
+    ax.axhline(0, color="black", lw=0.4, alpha=0.6)
+
+    if boundaries:
+        if boundaries_df is None:
+            from ..bulk.hic._insulation import tad_boundaries
+            boundaries_df = tad_boundaries(insulation_df, window_bp=window_bp)
+        bsub = boundaries_df[boundaries_df["chrom"] == chromosome]
+        if region_start is not None:
+            bsub = bsub[bsub["end"] > region_start]
+        if region_end is not None:
+            bsub = bsub[bsub["start"] < region_end]
+        bcenters = (bsub["start"] + bsub["end"]) / 2 / 1e6
+        ymin, ymax = ax.get_ylim()
+        ax.vlines(bcenters, ymin, ymin + 0.1 * (ymax - ymin),
+                  color="#c13e3e", lw=0.6, alpha=0.85)
+
+    ax.set_xlabel(f"{chromosome} (Mb)")
+    ax.set_ylabel(f"log2 insulation\n(window {int(window_bp)/1000:.0f} kb)")
+    ax.set_title(title or f"insulation — {chromosome}")
+    for sp in ("top", "right"):
+        ax.spines[sp].set_visible(False)
+    return fig, ax

--- a/tests/test_bulk_hic_insulation.py
+++ b/tests/test_bulk_hic_insulation.py
@@ -1,0 +1,123 @@
+"""Smoke tests for ``epione.bulk.hic.insulation`` / ``tad_boundaries``
+on a synthetic 4-Mb cool with three injected TAD-like blocks.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+pytest.importorskip("cooler")
+pytest.importorskip("cooltools")
+pytest.importorskip("matplotlib")
+
+
+def _make_cool_with_tads(tmp_path, seed=0):
+    """Synthetic 4-Mb single-chrom cool with three TAD blocks injected.
+
+    Within-block contacts fire ~10x more often than between-block, so
+    insulation troughs should appear around the two block boundaries.
+    """
+    import pysam
+    import epione as epi
+
+    rng = np.random.default_rng(seed)
+    chrom = "chrTAD"
+    size = 4_000_000
+    block_edges = [0, 1_300_000, 2_600_000, size]  # 3 blocks
+    sizes = tmp_path / "chrom.sizes"
+    sizes.write_text(f"{chrom}\t{size}\n")
+
+    pairs = tmp_path / "synt.pairs"
+    n_within_per_block = 25_000
+    n_between = 4_000
+    rid = 0
+    with pairs.open("w") as fh:
+        fh.write("## pairs format v1.0\n")
+        fh.write(f"#chromsize: {chrom} {size}\n")
+        fh.write(
+            "#columns: readID chrom1 pos1 chrom2 pos2 strand1 strand2\n"
+        )
+        for blk_start, blk_end in zip(block_edges[:-1], block_edges[1:]):
+            for _ in range(n_within_per_block):
+                p1 = rng.integers(blk_start, blk_end)
+                p2 = rng.integers(blk_start, blk_end)
+                if p1 > p2:
+                    p1, p2 = p2, p1
+                fh.write(f"r{rid}\t{chrom}\t{p1}\t{chrom}\t{p2}\t+\t+\n")
+                rid += 1
+        # Sparse between-block background (uniform)
+        for _ in range(n_between):
+            p1 = rng.integers(0, size)
+            p2 = rng.integers(0, size)
+            if p1 > p2:
+                p1, p2 = p2, p1
+            fh.write(f"r{rid}\t{chrom}\t{p1}\t{chrom}\t{p2}\t+\t+\n")
+            rid += 1
+
+    pairs_gz = tmp_path / "synt.pairs.gz"
+    pysam.tabix_compress(str(pairs), str(pairs_gz), force=True)
+    cool = tmp_path / "synt.cool"
+    epi.upstream.pairs_to_cool(pairs_gz, sizes, cool, binsize=20_000)
+    epi.bulk.hic.balance_cool(cool, mad_max=10, min_nnz=1, ignore_diags=0)
+    return cool, block_edges
+
+
+def test_insulation_returns_per_bin_score(tmp_path):
+    import epione as epi
+    cool, _ = _make_cool_with_tads(tmp_path)
+    df = epi.bulk.hic.insulation(
+        cool, window_bp=200_000, chromosomes=["chrTAD"],
+        ignore_diags=0,
+    )
+    score_cols = [c for c in df.columns
+                  if c.startswith("log2_insulation_score_")]
+    assert len(score_cols) == 1
+    assert (df["chrom"] == "chrTAD").all()
+    finite_score = df[score_cols[0]].dropna()
+    assert finite_score.size > 0
+
+
+def test_tad_boundaries_recovers_block_edges(tmp_path):
+    """Injected boundaries at 1.3 Mb / 2.6 Mb should be among the
+    strongest insulation dips."""
+    import epione as epi
+    cool, edges = _make_cool_with_tads(tmp_path)
+    df = epi.bulk.hic.insulation(
+        cool, window_bp=200_000, chromosomes=["chrTAD"],
+        ignore_diags=0,
+    )
+    boundaries = epi.bulk.hic.tad_boundaries(df, window_bp=200_000)
+    assert len(boundaries) > 0
+    # Sort by strength and pick top 5
+    top = boundaries.sort_values(
+        "boundary_strength", ascending=False
+    ).head(5)
+    top_centres = ((top["start"] + top["end"]) / 2).to_numpy()
+    # Each injected edge (1.3 Mb, 2.6 Mb) must have a top-5 boundary
+    # within ±400 kb (synthetic data has ~one bin worth of jitter).
+    for edge in (1_300_000, 2_600_000):
+        nearest = np.min(np.abs(top_centres - edge))
+        assert nearest < 400_000, (
+            f"no top-5 boundary within 400 kb of injected edge {edge}: "
+            f"top centres = {top_centres.tolist()}"
+        )
+
+
+def test_plot_insulation_renders(tmp_path):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import epione as epi
+    cool, _ = _make_cool_with_tads(tmp_path)
+    df = epi.bulk.hic.insulation(
+        cool, window_bp=200_000, chromosomes=["chrTAD"],
+        ignore_diags=0,
+    )
+    fig, ax = epi.pl.plot_insulation(
+        df, chromosome="chrTAD", window_bp=200_000,
+        figsize=(6, 1.5),
+    )
+    assert fig is not None
+    plt.close(fig)


### PR DESCRIPTION
## Context
Adds the diamond-insulation workflow — needed for **Maziak 2026 Fig 2** (boundary dynamics across NC stages) and **Chang 2024 Fig 1h** (per-cell-type insulation tracks). One function call covers the canonical "per-bin score → boundaries via Li thresholding" pipeline.

## What this PR adds
- `epione.bulk.hic.insulation(cool, window_bp, ...)` — wraps `cooltools.insulation`. Returns per-bin DataFrame with `log2_insulation_score_<W>`, `boundary_strength_<W>`, `is_boundary_<W>` columns. Pass a list to score multiple windows in one shot.
- `epione.bulk.hic.tad_boundaries(insulation_df, window_bp, min_strength)` — BED-shaped boundary set; either Li-auto-thresholded or user-defined.
- `epione.pl.plot_insulation(...)` — line plot of the score with optional boundary tickmarks. Region-zoom supported.

## Validation on real data
NC14 Drosophila Pico-C (Maziak 2026), 2 kb resolution, 20 kb window, 5 major chromosomes:

| Metric | Value |
|---|---|
| `insulation` runtime | ~2 min |
| Total boundaries called | 2,696 |
| chr2L:10-15 Mb plot | Canonical insulation peaks/troughs with boundary ticks landing on dip floors |

## Test plan
- [x] `pytest tests/test_bulk_hic_insulation.py` — 3/3 pass on synthetic 4-Mb 3-block TAD cool (boundaries near injected 1.3 / 2.6 Mb edges recovered in top-5 strongest)
- [x] Full suite: 78/78 (was 75)

## Roadmap (toward Chang 2024 Fig 1 reproduction)
- PR C (next): loop calling (cooltools.dots) → covers Maziak Fig 1/3 + Droplet Hi-C cell-type loop comparisons
- PR D: `epione.single.hic.demux_pairs_by_barcode` + `pseudobulk_by_celltype` + `cluster_correlation` — the missing pieces for end-to-end Droplet Hi-C reproduction
- PR E: Tutorial `t_droplet_hic_chang2024.ipynb` reproducing Fig 1 d/e/f/g/h on real GSE253407 data using only epione APIs