### PR TITLE
feat: epione.bulk.hic Phase 2C — loops (HICCUPS) + APA pile-up

### DIFF
--- a/epione/bulk/hic/__init__.py
+++ b/epione/bulk/hic/__init__.py
@@ -1,9 +1,10 @@
 """Bulk Hi-C analysis — companion to :mod:`epione.single.hic`.
 
-Operates on a single deeply-sequenced ``.cool`` / ``.mcool``. Phase
-1 covers ICE balancing; Phase 2 adds compartments + saddle + the
-pyramid contact view; Phase 2B (this commit) adds insulation score
-+ TAD-boundary calling.
+Operates on a single deeply-sequenced ``.cool`` / ``.mcool``.
+Phase 1 covers ICE balancing; Phase 2A adds compartments + saddle
++ pyramid; Phase 2B adds insulation + boundaries; Phase 2C (this
+commit) adds loops + APA pile-up — the full Maziak 2026 / Chang
+2024 reproduction stack.
 
 Public API (flat — call as ``epi.bulk.hic.X``):
     * :func:`balance_cool`            — ICE-balance a ``.cool``
@@ -11,6 +12,8 @@ Public API (flat — call as ``epi.bulk.hic.X``):
     * :func:`saddle`                  — compartment-strength matrix
     * :func:`insulation`              — diamond-insulation score
     * :func:`tad_boundaries`          — boundary BED from insulation
+    * :func:`loops`                   — HICCUPS-style dot finder
+    * :func:`pileup`                  — APA / aggregate stack
     * :func:`plot_contact_matrix`     — region heatmap
     * :func:`plot_contact_triangle`   — pyramid view of region
     * :func:`plot_decay_curve`        — P(s) QC plot
@@ -18,12 +21,15 @@ Public API (flat — call as ``epi.bulk.hic.X``):
     * :func:`plot_compartments`       — chromosome E1 track
     * :func:`plot_saddle`             — A/B saddle heatmap
     * :func:`plot_insulation`         — insulation score line + boundaries
+    * :func:`plot_loops`              — heatmap with dot overlay
+    * :func:`plot_apa`                — APA aggregate heatmap
 """
 from __future__ import annotations
 
 from ._balance import balance_cool
 from ._compartments import compartments, saddle
 from ._insulation import insulation, tad_boundaries
+from ._loops import loops, pileup
 # Plotting helpers live in :mod:`epione.pl` since v0.4 (PR 3); import
 # them from there so ``epi.bulk.hic.plot_*`` still resolves.
 from epione.pl._contact import (
@@ -34,6 +40,8 @@ from epione.pl._contact import (
     plot_compartments,
     plot_saddle,
     plot_insulation,
+    plot_loops,
+    plot_apa,
 )
 
 __all__ = [
@@ -42,6 +50,8 @@ __all__ = [
     "saddle",
     "insulation",
     "tad_boundaries",
+    "loops",
+    "pileup",
     "plot_contact_matrix",
     "plot_contact_triangle",
     "plot_decay_curve",
@@ -49,4 +59,6 @@ __all__ = [
     "plot_compartments",
     "plot_saddle",
     "plot_insulation",
+    "plot_loops",
+    "plot_apa",
 ]

--- a/epione/bulk/hic/_loops.py
+++ b/epione/bulk/hic/_loops.py
@@ -1,0 +1,180 @@
+"""Loop calling and aggregate pile-up analysis for bulk Hi-C.
+
+Wraps :func:`cooltools.dots` (HICCUPS-style dot finder) to call
+chromatin loops, and :func:`cooltools.pileup` to aggregate-stack a
+contact-matrix region around a set of features (loops, boundaries,
+peaks). These are the core analyses of Maziak 2026 Fig 1 / Fig 3
+(stage-specific loop emergence + APA pile-ups) and Chang 2024 Fig 1
+(per-cell-type loop comparison).
+
+Both functions take a balanced ``.cool`` and optional pre-computed
+expected; if expected is missing, it's computed on-the-fly.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Sequence, Union
+
+import numpy as np
+import pandas as pd
+
+
+def _resolve_uri(path: Union[str, Path], resolution: Optional[int]) -> str:
+    p = str(path)
+    if "::" in p:
+        return p
+    if resolution is None:
+        return p
+    return f"{p}::resolutions/{int(resolution)}"
+
+
+def _ensure_expected_cis(clr, view, ignore_diags: int = 2):
+    """Compute (or return cached) expected_cis for a cooler + view."""
+    from cooltools.api.expected import expected_cis
+    return expected_cis(
+        clr=clr, view_df=view, ignore_diags=ignore_diags,
+        chunksize=1_000_000,
+    )
+
+
+def loops(
+    cool_path: Union[str, Path],
+    *,
+    resolution: Optional[int] = None,
+    chromosomes: Optional[Sequence[str]] = None,
+    max_loci_separation: int = 10_000_000,
+    fdr: float = 0.1,
+    clustering_radius: int = 20_000,
+    nproc: int = 1,
+) -> pd.DataFrame:
+    """Call chromatin loops (HICCUPS-style dots) on a balanced cool.
+
+    Wraps :func:`cooltools.dots` end-to-end: builds the ``expected_cis``
+    on the fly, runs the dot-finder with the standard 4-kernel set,
+    applies BH-FDR correction at ``fdr``, and clusters nearby calls
+    within ``clustering_radius`` so each loop is a single anchor pair.
+
+    Arguments:
+        cool_path: balanced ``.cool`` / ``.mcool::resolutions/N`` (must
+            have a ``weight`` column).
+        resolution: bp resolution for ``.mcool``.
+        chromosomes: subset; default = all in the cool.
+        max_loci_separation: maximum loop anchor separation (bp).
+            ``10_000_000`` (10 Mb) is the cooltools / HICCUPS default.
+        fdr: BH-FDR threshold per ``lambda_bin``. ``0.1`` = standard.
+        clustering_radius: anchor-pair clustering distance (bp);
+            within this, multiple sub-significant pixels are merged
+            into one loop call. ``20_000`` = cooltools default.
+        nproc: parallel workers for tile scanning.
+
+    Returns:
+        BEDPE-shaped DataFrame: one row per called loop. Columns:
+        ``chrom1, start1, end1, chrom2, start2, end2`` (anchors),
+        plus cooltools-internal columns (``count``, ``la_exp.*``,
+        ``la_p.*``, etc.) — keep them for filtering/sorting; drop
+        before exporting if you only want the BEDPE shape.
+    """
+    import cooler
+    import cooltools
+
+    clr = cooler.Cooler(_resolve_uri(cool_path, resolution))
+    if chromosomes is not None:
+        view = pd.DataFrame({
+            "chrom": list(chromosomes),
+            "start": [0] * len(chromosomes),
+            "end": [int(clr.chromsizes[c]) for c in chromosomes],
+            "name": list(chromosomes),
+        })
+    else:
+        view = pd.DataFrame({
+            "chrom": list(clr.chromnames),
+            "start": [0] * len(clr.chromnames),
+            "end": [int(clr.chromsizes[c]) for c in clr.chromnames],
+            "name": list(clr.chromnames),
+        })
+
+    expected = _ensure_expected_cis(clr, view, ignore_diags=2)
+
+    df = cooltools.dots(
+        clr=clr,
+        expected=expected,
+        view_df=view,
+        max_loci_separation=int(max_loci_separation),
+        lambda_bin_fdr=float(fdr),
+        clustering_radius=int(clustering_radius),
+        nproc=int(nproc),
+    )
+    return df
+
+
+def pileup(
+    cool_path: Union[str, Path],
+    features_df: pd.DataFrame,
+    *,
+    resolution: Optional[int] = None,
+    flank: int = 100_000,
+    chromosomes: Optional[Sequence[str]] = None,
+    expected: Optional[pd.DataFrame] = None,
+    nproc: int = 1,
+) -> np.ndarray:
+    """Aggregate-stack contact matrix around a set of genomic features.
+
+    For each feature in ``features_df`` (loops, boundaries, ChIP peaks
+    etc.), pull the contact-matrix sub-region of side ``2*flank+binsize``
+    centred on the feature and average across the set. Returns the
+    ``(2*flank+binsize) // binsize`` × ditto observed-over-expected
+    average — the canonical APA / boundary-pile-up plot from Maziak /
+    Chang papers.
+
+    Arguments:
+        cool_path: balanced ``.cool`` / ``.mcool::resolutions/N``.
+        features_df: bed3 (boundary pile-up) or bedpe (loop APA)
+            DataFrame. cooltools auto-detects shape from columns.
+        resolution: bp resolution for ``.mcool``.
+        flank: bp on each side of the feature centre. The output
+            matrix is square with side ``2*flank/binsize + 1``.
+        chromosomes: subset for the on-the-fly expected.
+        expected: pre-computed expected_cis (skip recompute).
+        nproc: parallel workers.
+
+    Returns:
+        2-D ``numpy.ndarray`` of mean observed-over-expected contact
+        frequency. The centre cell is the feature itself; corners are
+        ``flank`` bp away on both axes.
+    """
+    import cooler
+    import cooltools
+
+    clr = cooler.Cooler(_resolve_uri(cool_path, resolution))
+    if chromosomes is not None:
+        view = pd.DataFrame({
+            "chrom": list(chromosomes),
+            "start": [0] * len(chromosomes),
+            "end": [int(clr.chromsizes[c]) for c in chromosomes],
+            "name": list(chromosomes),
+        })
+    else:
+        view = pd.DataFrame({
+            "chrom": list(clr.chromnames),
+            "start": [0] * len(clr.chromnames),
+            "end": [int(clr.chromsizes[c]) for c in clr.chromnames],
+            "name": list(clr.chromnames),
+        })
+
+    if expected is None:
+        expected = _ensure_expected_cis(clr, view, ignore_diags=2)
+
+    stack = cooltools.pileup(
+        clr=clr,
+        features_df=features_df,
+        view_df=view,
+        expected_df=expected,
+        flank=int(flank),
+        nproc=int(nproc),
+    )
+    # cooltools returns a 3-D stack (n_features, side, side); average
+    # along the feature axis to give the standard APA matrix.
+    arr = np.asarray(stack)
+    if arr.ndim == 3:
+        arr = np.nanmean(arr, axis=0)
+    return arr

--- a/epione/pl/__init__.py
+++ b/epione/pl/__init__.py
@@ -18,6 +18,8 @@ from ._contact import (
     plot_compartments,
     plot_saddle,
     plot_insulation,
+    plot_loops,
+    plot_apa,
 )
 
 from ._peak2gene import plot_peak2gene
@@ -52,6 +54,7 @@ __all__ = [
     "plot_cell_contacts",
     "plot_compartments", "plot_saddle",
     "plot_insulation",
+    "plot_loops", "plot_apa",
     "plot_peak2gene",
     "plot_footprints",
     "plot_multi_scale_footprint",

--- a/epione/pl/_contact.py
+++ b/epione/pl/_contact.py
@@ -716,3 +716,133 @@ def plot_insulation(
     for sp in ("top", "right"):
         ax.spines[sp].set_visible(False)
     return fig, ax
+
+
+def plot_apa(
+    apa_matrix,
+    *,
+    flank: Optional[int] = None,
+    binsize: Optional[int] = None,
+    cmap: str = "coolwarm",
+    vmin: float = -1.0,
+    vmax: float = 1.0,
+    log: bool = True,
+    figsize: Tuple[float, float] = (4.0, 3.6),
+    title: Optional[str] = None,
+    ax=None,
+    colorbar: bool = True,
+):
+    """Aggregate peak-analysis (APA) heatmap from
+    :func:`epione.bulk.hic.pileup`.
+
+    Arguments:
+        apa_matrix: 2-D mean observed-over-expected matrix.
+        flank, binsize: tick-label hints; if both supplied, axis ticks
+            show distance from feature centre in kb.
+        cmap, vmin, vmax: ``coolwarm ±1`` log2(O/E) is the cooltools
+            APA convention. ``log`` log2-transforms a linear input.
+        figsize, title, ax, colorbar: cosmetic.
+
+    Returns:
+        ``(fig, ax, img)``.
+    """
+    import matplotlib.pyplot as plt
+
+    M = np.asarray(apa_matrix, dtype=np.float64)
+    if log and (M >= 0).all():
+        with np.errstate(divide="ignore"):
+            M = np.log2(M)
+        M = np.where(np.isfinite(M), M, np.nan)
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+
+    img = ax.imshow(M, origin="lower", cmap=cmap,
+                    vmin=vmin, vmax=vmax, interpolation="none")
+    n = M.shape[0]
+    if flank is not None and binsize is not None:
+        # tick at ±flank corners + 0 centre
+        ticks = [0, n // 2, n - 1]
+        ax.set_xticks(ticks)
+        ax.set_yticks(ticks)
+        labels = [f"-{flank/1000:.0f} kb", "0", f"+{flank/1000:.0f} kb"]
+        ax.set_xticklabels(labels)
+        ax.set_yticklabels(labels)
+    ax.set_title(title or "APA")
+    if colorbar:
+        fig.colorbar(img, ax=ax, shrink=0.8,
+                     label="log2(O/E)" if log else "O/E")
+    return fig, ax, img
+
+
+def plot_loops(
+    cool_path,
+    region: str,
+    loops_df,
+    *,
+    balance: bool = True,
+    cmap: str = "YlOrRd",
+    log: bool = True,
+    figsize: Tuple[float, float] = (6.0, 5.5),
+    loop_color: str = "#1f4e79",
+    loop_marker: str = "o",
+    loop_size: float = 30.0,
+    title: Optional[str] = None,
+    ax=None,
+):
+    """Contact-matrix heatmap with called loop dots overlaid.
+
+    Renders :func:`plot_contact_matrix` for ``region`` and adds
+    scatter markers at every loop in ``loops_df`` whose anchors fall
+    inside the window — the canonical figure 1 / 3 panel from
+    Maziak 2026 / Chang 2024 showing dot-finder calls in context.
+
+    Arguments:
+        cool_path: ``.cool`` / ``.mcool::resolutions/N``.
+        region: UCSC interval (underscores / commas allowed).
+        loops_df: BEDPE-shaped DataFrame from
+            :func:`epione.bulk.hic.loops` (must have ``chrom1, start1,
+            end1, chrom2, start2, end2``).
+        balance, cmap, log: forwarded to ``plot_contact_matrix``.
+        figsize, ax, title: cosmetic.
+        loop_color, loop_marker, loop_size: scatter style for the
+            overlay.
+
+    Returns:
+        ``(fig, ax)``.
+    """
+    import matplotlib.pyplot as plt
+
+    fig, ax_, _ = plot_contact_matrix(
+        cool_path, region=region,
+        balance=balance, cmap=cmap, log=log,
+        figsize=figsize, title=title, ax=ax, colorbar=True,
+    )
+
+    chrom = region.split(":", 1)[0] if ":" in region else region
+    if ":" in region:
+        span = region.split(":", 1)[1]
+        lo_str, hi_str = span.replace(",", "").replace("_", "").split("-")
+        lo, hi = int(lo_str), int(hi_str)
+    else:
+        import cooler
+        c = cooler.Cooler(str(cool_path))
+        lo = 0
+        hi = int(c.chromsizes[chrom])
+
+    sub = loops_df[
+        (loops_df["chrom1"] == chrom) & (loops_df["chrom2"] == chrom)
+        & (loops_df["start1"] >= lo) & (loops_df["end1"] <= hi)
+        & (loops_df["start2"] >= lo) & (loops_df["end2"] <= hi)
+    ]
+    x = (sub["start1"] + sub["end1"]) / 2
+    y = (sub["start2"] + sub["end2"]) / 2
+    # plot_contact_matrix uses extent=[lo, hi, hi, lo] — so y-axis is
+    # flipped. Plot loops at both (x, y) and (y, x) so they show up on
+    # both upper / lower triangles, matching the symmetric heatmap.
+    ax_.scatter(np.r_[x, y], np.r_[y, x],
+                s=loop_size, marker=loop_marker,
+                facecolors="none", edgecolors=loop_color, linewidths=1.2)
+    return fig, ax_

--- a/tests/test_bulk_hic_loops.py
+++ b/tests/test_bulk_hic_loops.py
@@ -1,0 +1,165 @@
+"""Smoke tests for ``epione.bulk.hic.loops`` and ``pileup`` on a small
+synthetic cool with injected dot-like signal.
+
+cooltools' HICCUPS-style dot finder needs reasonably populated matrices
+to fire (4-kernel BH-FDR over ``lambda_bin``); we don't assert that any
+specific loop is recovered here — we test the API contract (shapes,
+column names, dtypes) and that ``pileup`` averages a known feature set
+correctly.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+pytest.importorskip("cooler")
+pytest.importorskip("cooltools")
+pytest.importorskip("matplotlib")
+
+
+def _make_cool_with_dots(tmp_path, seed=0):
+    """Synthetic 6-Mb cool with two pairs of strong dots injected.
+
+    Background = uniform cis contacts. On top, inject extra contacts
+    between two anchor pairs (dot1 = 1.5/3.5 Mb, dot2 = 2.0/4.5 Mb)
+    so the (i, j) cell in the contact matrix lights up.
+    """
+    import pysam
+    import epione as epi
+
+    rng = np.random.default_rng(seed)
+    chrom = "chrL"
+    size = 6_000_000
+    sizes = tmp_path / "chrom.sizes"
+    sizes.write_text(f"{chrom}\t{size}\n")
+
+    pairs = tmp_path / "synt.pairs"
+    n_bg = 100_000
+    n_dot = 6_000
+    rid = 0
+    dot_anchors = [(1_500_000, 3_500_000), (2_000_000, 4_500_000)]
+    anchor_window = 30_000  # ±30 kb around each anchor
+    with pairs.open("w") as fh:
+        fh.write("## pairs format v1.0\n")
+        fh.write(f"#chromsize: {chrom} {size}\n")
+        fh.write(
+            "#columns: readID chrom1 pos1 chrom2 pos2 strand1 strand2\n"
+        )
+        # Uniform cis background
+        for _ in range(n_bg):
+            p1 = rng.integers(0, size)
+            p2 = rng.integers(0, size)
+            if p1 > p2:
+                p1, p2 = p2, p1
+            fh.write(f"r{rid}\t{chrom}\t{p1}\t{chrom}\t{p2}\t+\t+\n")
+            rid += 1
+        # Dot anchors
+        for a, b in dot_anchors:
+            for _ in range(n_dot):
+                p1 = a + rng.integers(-anchor_window, anchor_window)
+                p2 = b + rng.integers(-anchor_window, anchor_window)
+                if p1 > p2:
+                    p1, p2 = p2, p1
+                fh.write(f"r{rid}\t{chrom}\t{p1}\t{chrom}\t{p2}\t+\t+\n")
+                rid += 1
+
+    pairs_gz = tmp_path / "synt.pairs.gz"
+    pysam.tabix_compress(str(pairs), str(pairs_gz), force=True)
+    cool = tmp_path / "synt.cool"
+    epi.upstream.pairs_to_cool(pairs_gz, sizes, cool, binsize=20_000)
+    epi.bulk.hic.balance_cool(cool, mad_max=10, min_nnz=1, ignore_diags=0)
+    return cool, dot_anchors
+
+
+def test_loops_returns_bedpe_shape(tmp_path):
+    """``loops()`` runs end-to-end and returns a BEDPE-shaped DataFrame
+    (may be empty on tiny synthetic data — we test the contract)."""
+    import epione as epi
+    cool, _ = _make_cool_with_dots(tmp_path)
+    df = epi.bulk.hic.loops(
+        cool, chromosomes=["chrL"],
+        max_loci_separation=5_000_000,
+        fdr=0.2,
+        clustering_radius=40_000,
+    )
+    assert isinstance(df, pd.DataFrame)
+    for col in ("chrom1", "start1", "end1", "chrom2", "start2", "end2"):
+        assert col in df.columns, f"missing BEDPE column {col!r}"
+    if len(df):
+        # When loops are called, anchors must satisfy chrom1 == chrom2
+        # and start1 < start2 (cis only, upper triangle).
+        assert (df["chrom1"] == df["chrom2"]).all()
+        assert (df["start1"] <= df["start2"]).all()
+
+
+def test_pileup_returns_square_matrix(tmp_path):
+    """``pileup()`` over a 2-feature BEDPE must return a square 2-D
+    array of side ``2*flank/binsize + 1``."""
+    import epione as epi
+    cool, anchors = _make_cool_with_dots(tmp_path)
+    flank = 100_000
+    binsize = 20_000
+    feats = pd.DataFrame({
+        "chrom1": ["chrL"] * len(anchors),
+        "start1": [a[0] for a in anchors],
+        "end1":   [a[0] + binsize for a in anchors],
+        "chrom2": ["chrL"] * len(anchors),
+        "start2": [a[1] for a in anchors],
+        "end2":   [a[1] + binsize for a in anchors],
+    })
+    apa = epi.bulk.hic.pileup(
+        cool, feats, flank=flank, chromosomes=["chrL"],
+    )
+    assert apa.ndim == 2
+    assert apa.shape[0] == apa.shape[1]
+    expected_side = (2 * flank) // binsize + 1
+    assert apa.shape[0] == expected_side, (
+        f"expected side {expected_side}, got {apa.shape[0]}"
+    )
+    finite = apa[np.isfinite(apa)]
+    assert finite.size > 0
+
+
+def test_plot_apa_renders(tmp_path):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import epione as epi
+    cool, anchors = _make_cool_with_dots(tmp_path)
+    feats = pd.DataFrame({
+        "chrom1": ["chrL"] * len(anchors),
+        "start1": [a[0] for a in anchors],
+        "end1":   [a[0] + 20_000 for a in anchors],
+        "chrom2": ["chrL"] * len(anchors),
+        "start2": [a[1] for a in anchors],
+        "end2":   [a[1] + 20_000 for a in anchors],
+    })
+    apa = epi.bulk.hic.pileup(
+        cool, feats, flank=80_000, chromosomes=["chrL"],
+    )
+    fig, ax, img = epi.pl.plot_apa(
+        apa, flank=80_000, binsize=20_000, figsize=(3.5, 3.2),
+    )
+    assert fig is not None
+    plt.close(fig)
+
+
+def test_plot_loops_renders_without_calls(tmp_path):
+    """``plot_loops`` should render fine even if ``loops_df`` is empty
+    (no dots called) — useful when a region is loop-free."""
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import epione as epi
+    cool, _ = _make_cool_with_dots(tmp_path)
+    empty = pd.DataFrame(columns=[
+        "chrom1", "start1", "end1", "chrom2", "start2", "end2",
+    ])
+    fig, ax = epi.pl.plot_loops(
+        cool, region="chrL:1,000,000-5,000,000",
+        loops_df=empty, figsize=(4, 3.6),
+    )
+    assert fig is not None
+    plt.close(fig)


### PR DESCRIPTION
## Summary

Final piece of the bulk-Hi-C reproduction stack — **loop calling** and **aggregate pile-up** — so a balanced cool can flow all the way from `pairs_to_cool` → `balance_cool` → `compartments` / `saddle` (#27) → `insulation` / `tad_boundaries` (#28) → **`loops` / `pileup`** (this PR), reproducing Maziak 2026 Fig 1/3 and Chang 2024 Fig 1.

* `epione.bulk.hic.loops` — wraps `cooltools.dots` (HICCUPS 4-kernel dot finder) end-to-end: builds `expected_cis` on the fly, runs the dot scan, applies BH-FDR per `lambda_bin`, clusters within `clustering_radius`. Returns a BEDPE-shaped DataFrame.
* `epione.bulk.hic.pileup` — wraps `cooltools.pileup` for APA (loops) or boundary pile-up (TAD edges). Averages cooltools' per-feature 3-D stack along the feature axis to give the canonical 2-D mean-O/E heatmap.
* `epione.pl.plot_apa` — coolwarm log2(O/E) APA heatmap with kb tick labels.
* `epione.pl.plot_loops` — contact-matrix heatmap with called dot overlay (anchors mirrored to both triangles of the symmetric map).

## Test plan

- [x] `tests/test_bulk_hic_loops.py` — 4 new tests on a synthetic 6-Mb single-chrom cool with 2 injected dot anchor pairs:
    - `loops()` returns a BEDPE-shaped DataFrame (cis only, anchors ordered);
    - `pileup()` returns a square (2·flank/binsize + 1)² mean-O/E matrix;
    - `plot_apa` renders;
    - `plot_loops` renders even on an empty BEDPE (loop-free regions).
- [x] Full suite: 78 → 82 tests passing locally (`pytest -x -q`).
- [ ] CI green on Python 3.10/3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)