### PR TITLE
feat: epione.single.hic Phase 2 — Droplet Hi-C demux + pseudobulk + correlation

### DIFF
--- a/epione/pl/__init__.py
+++ b/epione/pl/__init__.py
@@ -20,6 +20,7 @@ from ._contact import (
     plot_insulation,
     plot_loops,
     plot_apa,
+    plot_correlation_heatmap,
 )
 
 from ._peak2gene import plot_peak2gene
@@ -55,6 +56,7 @@ __all__ = [
     "plot_compartments", "plot_saddle",
     "plot_insulation",
     "plot_loops", "plot_apa",
+    "plot_correlation_heatmap",
     "plot_peak2gene",
     "plot_footprints",
     "plot_multi_scale_footprint",

--- a/epione/pl/_contact.py
+++ b/epione/pl/_contact.py
@@ -846,3 +846,88 @@ def plot_loops(
                 s=loop_size, marker=loop_marker,
                 facecolors="none", edgecolors=loop_color, linewidths=1.2)
     return fig, ax_
+
+
+def plot_correlation_heatmap(
+    corr,
+    *,
+    names: Optional[list] = None,
+    cmap: str = "RdBu_r",
+    vmin: Optional[float] = None,
+    vmax: Optional[float] = None,
+    annotate: bool = True,
+    annot_fmt: str = ".2f",
+    annot_fontsize: float = 7.0,
+    figsize: Tuple[float, float] = (4.5, 4.0),
+    title: Optional[str] = None,
+    ax=None,
+    colorbar: bool = True,
+):
+    """Symmetric celltype × celltype correlation heatmap (Chang 2024 Fig 1f).
+
+    Renders a square heatmap of the matrix returned by
+    :func:`epione.single.hic.cluster_correlation` — diverging RdBu_r
+    by default, with cell values annotated. Designed for the small-N
+    case (≤ ~20 celltypes); for larger N, switch to ``annotate=False``.
+
+    Arguments:
+        corr: square correlation matrix as a ``DataFrame`` (with
+            row/column = celltype names) or 2-D ``ndarray``.
+        names: celltype labels — required if ``corr`` is an ndarray;
+            ignored if ``corr`` is a DataFrame.
+        cmap, vmin, vmax: colourmap + range. Default ``vmin = corr.min()``,
+            ``vmax = 1.0``.
+        annotate: write the correlation value in each cell.
+        annot_fmt, annot_fontsize: annotation format / size.
+        figsize, ax, title, colorbar: cosmetic.
+
+    Returns:
+        ``(fig, ax, img)``.
+    """
+    import matplotlib.pyplot as plt
+    import pandas as pd
+
+    if isinstance(corr, pd.DataFrame):
+        names = list(corr.index)
+        M = corr.to_numpy()
+    else:
+        M = np.asarray(corr)
+        if names is None:
+            names = [str(i) for i in range(M.shape[0])]
+        if len(names) != M.shape[0]:
+            raise ValueError("len(names) must equal corr.shape[0]")
+
+    if vmin is None:
+        vmin = float(np.nanmin(M))
+    if vmax is None:
+        vmax = 1.0
+
+    if ax is None:
+        fig, ax = plt.subplots(figsize=figsize)
+    else:
+        fig = ax.figure
+
+    img = ax.imshow(M, cmap=cmap, vmin=vmin, vmax=vmax,
+                    interpolation="none")
+    n = M.shape[0]
+    ax.set_xticks(range(n))
+    ax.set_yticks(range(n))
+    ax.set_xticklabels(names, rotation=45, ha="right")
+    ax.set_yticklabels(names)
+
+    if annotate:
+        for i in range(n):
+            for j in range(n):
+                v = M[i, j]
+                if not np.isfinite(v):
+                    continue
+                rel = (v - vmin) / max(vmax - vmin, 1e-9)
+                color = "white" if (rel < 0.2 or rel > 0.8) else "black"
+                ax.text(j, i, format(v, annot_fmt),
+                        ha="center", va="center",
+                        color=color, fontsize=annot_fontsize)
+
+    ax.set_title(title or "celltype correlation")
+    if colorbar:
+        fig.colorbar(img, ax=ax, shrink=0.8, label="Pearson r")
+    return fig, ax, img

--- a/epione/single/hic/__init__.py
+++ b/epione/single/hic/__init__.py
@@ -1,27 +1,37 @@
 """Single-cell Hi-C analysis — companion to :mod:`epione.bulk.hic`.
 
-Phase 1 (this module) covers scHiCluster (Zhou et al. 2019, PNAS):
-each per-cell ``.cool`` is densified by linear-conv + RWR + top-k,
-imputed matrices are flattened into a cell × feature matrix, PCA
-gives the cell embedding ready for scanpy ``neighbors`` / ``umap`` /
-``leiden`` downstream.
+Phase 1 covers scHiCluster (Zhou et al. 2019, PNAS): each per-cell
+``.cool`` is densified by linear-conv + RWR + top-k, imputed matrices
+are flattened into a cell × feature matrix, PCA gives the cell
+embedding ready for scanpy ``neighbors`` / ``umap`` / ``leiden``
+downstream.
+
+Phase 2 (Chang 2024 Droplet Hi-C) adds the per-celltype reduction:
+demux a multi-cell pairs file by barcode, build one ``.cool`` per
+celltype, and quantify celltype × celltype similarity via cis
+contact-vector correlation — the upstream of Chang 2024 Fig 1d/e/f.
 
 Public API (flat — call as ``epi.single.hic.X``):
-    * :func:`load_cool_collection` — index per-cell ``.cool`` paths
-    * :func:`load_scool_cells`     — index a multi-cell ``.scool`` bundle
-    * :func:`impute_cell_chromosome` — pure-numpy core (one matrix)
-    * :func:`impute_cells`         — driver over a cell collection
-    * :func:`embedding`            — PCA on flattened imputed contacts
+    * :func:`load_cool_collection`     — index per-cell ``.cool`` paths
+    * :func:`load_scool_cells`         — index a multi-cell ``.scool`` bundle
+    * :func:`impute_cell_chromosome`   — pure-numpy core (one matrix)
+    * :func:`impute_cells`             — driver over a cell collection
+    * :func:`embedding`                — PCA on flattened imputed contacts
+    * :func:`demux_pairs_by_barcode`   — split multi-cell pairs by celltype
+    * :func:`pseudobulk_by_celltype`   — demux + ``pairs_to_cool`` + balance
+    * :func:`cluster_correlation`      — celltype × celltype Pearson r
 """
 from __future__ import annotations
 
 from ._io import load_cool_collection, load_scool_cells
 from ._impute import impute_cell_chromosome, impute_cells
 from ._embed import embedding
+from ._demux import demux_pairs_by_barcode, pseudobulk_by_celltype
+from ._correlation import cluster_correlation
 # Plotting helpers live in :mod:`epione.pl` since v0.4 (PR 3); import
-# them from there so ``epi.single.hic.plot_embedding`` still resolves.
+# them from there so ``epi.single.hic.plot_*`` still resolves.
 from epione.pl._embedding import plot_embedding
-from epione.pl._contact import plot_cell_contacts
+from epione.pl._contact import plot_cell_contacts, plot_correlation_heatmap
 
 __all__ = [
     "load_cool_collection",
@@ -29,6 +39,10 @@ __all__ = [
     "impute_cell_chromosome",
     "impute_cells",
     "embedding",
+    "demux_pairs_by_barcode",
+    "pseudobulk_by_celltype",
+    "cluster_correlation",
     "plot_embedding",
     "plot_cell_contacts",
+    "plot_correlation_heatmap",
 ]

--- a/epione/single/hic/_correlation.py
+++ b/epione/single/hic/_correlation.py
@@ -1,0 +1,144 @@
+"""Pairwise correlation across per-celltype Hi-C maps.
+
+Chang 2024 Fig 1f shows a celltype × celltype Pearson correlation
+heatmap built from cis contact-matrix vectors — celltype maps that
+share compartment / TAD architecture cluster together. This module
+turns a dict of ``{celltype: cool_path}`` (the output of
+:func:`epione.single.hic.pseudobulk_by_celltype`) into the
+correlation matrix that feeds
+:func:`epione.pl.plot_correlation_heatmap`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Mapping, Optional, Sequence, Tuple, Union
+
+import numpy as np
+import pandas as pd
+
+
+def _resolve_uri(path: Union[str, Path], resolution: Optional[int]) -> str:
+    p = str(path)
+    if "::" in p:
+        return p
+    if resolution is None:
+        return p
+    return f"{p}::resolutions/{int(resolution)}"
+
+
+def _flatten_cis(
+    cool_path: Union[str, Path],
+    *,
+    chromosomes: Optional[Sequence[str]] = None,
+    resolution: Optional[int] = None,
+    balance: bool = True,
+    log: bool = True,
+) -> np.ndarray:
+    """Flatten the upper-triangle cis pixels of a cool into a 1-D vector.
+
+    Skips trans pixels (different chrom1 vs chrom2) — celltype
+    correlation is dominated by cis structure (compartments + TADs +
+    loops), and trans pixels add noise + memory.
+    """
+    import cooler
+
+    clr = cooler.Cooler(_resolve_uri(cool_path, resolution))
+    bins = clr.bins()[:]
+    if chromosomes is not None:
+        keep = bins["chrom"].isin(list(chromosomes)).to_numpy()
+    else:
+        keep = np.ones(len(bins), dtype=bool)
+
+    out_chunks: list[np.ndarray] = []
+    for chrom in (chromosomes or clr.chromnames):
+        if chrom not in clr.chromnames:
+            continue
+        M = clr.matrix(balance=balance).fetch(chrom)
+        if M.size == 0:
+            continue
+        # Keep only the strict upper triangle; main diag dominated
+        # by self-ligation, lower triangle is symmetric.
+        iu = np.triu_indices_from(M, k=1)
+        v = M[iu].astype(np.float64, copy=False)
+        if log:
+            with np.errstate(divide="ignore", invalid="ignore"):
+                v = np.log2(v + 1e-9)
+            v = np.where(np.isfinite(v), v, np.nan)
+        out_chunks.append(v)
+    return np.concatenate(out_chunks) if out_chunks else np.zeros(0)
+
+
+def cluster_correlation(
+    cool_paths: Mapping[str, Union[str, Path]],
+    *,
+    chromosomes: Optional[Sequence[str]] = None,
+    resolution: Optional[int] = None,
+    balance: bool = True,
+    log: bool = True,
+) -> Tuple[pd.DataFrame, list[str]]:
+    """Pairwise Pearson correlation across per-celltype contact maps.
+
+    For each input cool, flattens the (balanced, log-transformed by
+    default) cis upper-triangle into a 1-D vector; then computes the
+    full pairwise Pearson correlation matrix. Bin pairs with NaN in
+    *any* celltype are dropped before correlation so all pairs are
+    over a common support.
+
+    Arguments:
+        cool_paths: ``{celltype: cool_path}`` (e.g. output of
+            :func:`pseudobulk_by_celltype`).
+        chromosomes: subset to use. Default = chromosomes present in
+            *every* cool.
+        resolution: bp resolution for ``.mcool`` (passed through to
+            each cool).
+        balance: read ICE-balanced contacts (default). Set ``False``
+            for raw counts.
+        log: log2-transform before correlating — standard for Hi-C
+            because the contact-frequency distribution is heavy-tailed.
+
+    Returns:
+        ``(corr_df, names)`` — ``corr_df`` is a square
+        ``DataFrame`` indexed by celltype name; ``names`` is the
+        celltype order (handy for plotting).
+    """
+    names = list(cool_paths.keys())
+    if not names:
+        raise ValueError("cool_paths is empty")
+
+    if chromosomes is None:
+        import cooler
+        seen = None
+        for p in cool_paths.values():
+            clr = cooler.Cooler(_resolve_uri(p, resolution))
+            seen = set(clr.chromnames) if seen is None else seen & set(clr.chromnames)
+        chromosomes = sorted(seen or [])
+
+    vecs: list[np.ndarray] = []
+    for nm in names:
+        v = _flatten_cis(
+            cool_paths[nm],
+            chromosomes=chromosomes,
+            resolution=resolution,
+            balance=balance,
+            log=log,
+        )
+        vecs.append(v)
+
+    if len(set(v.shape[0] for v in vecs)) != 1:
+        raise ValueError(
+            "celltype cools have different bin counts on the chosen "
+            "chromosomes — they must share the same cooler binning."
+        )
+
+    M = np.vstack(vecs)
+    finite = np.all(np.isfinite(M), axis=0)
+    M = M[:, finite]
+    if M.shape[1] == 0:
+        raise ValueError(
+            "no shared finite cis pixels across celltypes — check "
+            "balancing / chromosomes / resolution."
+        )
+
+    corr = np.corrcoef(M)
+    df = pd.DataFrame(corr, index=names, columns=names)
+    return df, names

--- a/epione/single/hic/_demux.py
+++ b/epione/single/hic/_demux.py
@@ -1,0 +1,203 @@
+"""Per-barcode / per-cluster demultiplexing of a single-cell pairs file.
+
+Droplet Hi-C (Chang 2024) and similar single-cell Hi-C protocols
+co-encapsulate many cells per droplet, so the aligned ``.pairs`` file
+holds reads from every cell mixed together — each line carries a
+cell-barcode tag (Chang's convention: appended to ``readID`` as
+``read123_<16bp-barcode>``). To get per-celltype contact maps you need
+two passes:
+
+* split that mixed pairs file into one pairs file per celltype
+  (:func:`demux_pairs_by_barcode`); then
+* run ``pairs_to_cool`` on each, giving one ``.cool`` per celltype
+  (:func:`pseudobulk_by_celltype`).
+
+This module is the upstream of Chang 2024 Fig 1d/e/f/g/h — the per-
+celltype compartment / loop / correlation comparisons.
+"""
+from __future__ import annotations
+
+import gzip
+import io
+import re
+from pathlib import Path
+from typing import Callable, Dict, Mapping, Optional, Union
+
+import pandas as pd
+
+
+def _open_text(path: Union[str, Path], mode: str = "rt"):
+    """Stream-open a ``.pairs`` or ``.pairs.gz`` file as text."""
+    p = str(path)
+    if p.endswith(".gz") or p.endswith(".bgz"):
+        return gzip.open(p, mode)
+    return open(p, mode)
+
+
+def _default_extract_barcode(read_id: str) -> str:
+    """Last underscore-delimited token of ``read_id`` (Chang 2024 layout).
+
+    Example: ``"NS500_ATAC123_AAACCTGAGAACTGTA-1"`` → ``"AAACCTGAGAACTGTA-1"``.
+    Override via :func:`demux_pairs_by_barcode`'s ``extract_barcode=``.
+    """
+    return read_id.rsplit("_", 1)[-1] if "_" in read_id else read_id
+
+
+def demux_pairs_by_barcode(
+    pairs_path: Union[str, Path],
+    barcode_to_group: Mapping[str, str],
+    output_dir: Union[str, Path],
+    *,
+    barcode_column: Optional[int] = None,
+    extract_barcode: Optional[Callable[[str], str]] = None,
+    gzip_output: bool = True,
+    drop_unassigned: bool = True,
+) -> Dict[str, Path]:
+    """Split a multi-cell ``.pairs`` file into one pairs file per group.
+
+    Each input line is read, its cell-barcode is extracted, and the
+    line is appended to the output stream of the group that barcode
+    maps to (e.g. ``"AAACCTGAGAACTGTA-1" → "T_cell"``). The 4DN
+    pairs header (``##`` + ``#chromsize:`` + ``#columns:`` lines) is
+    propagated verbatim into every output file.
+
+    Arguments:
+        pairs_path: input ``.pairs`` or ``.pairs.gz``.
+        barcode_to_group: mapping ``barcode → group_name`` (e.g.
+            celltype label from a clustering). Pass a ``dict`` or a
+            ``pandas.Series``.
+        output_dir: directory for ``{group}.pairs.gz``. Created if
+            absent.
+        barcode_column: 1-based column index in the pairs body
+            (``readID`` is column 1). If ``None``, ``extract_barcode``
+            is applied to ``readID`` instead.
+        extract_barcode: callable ``readID → barcode``. Default =
+            split on the last ``_`` (Chang 2024 convention). Ignored
+            if ``barcode_column`` is given.
+        gzip_output: write ``.pairs.gz`` (default) or plain ``.pairs``.
+        drop_unassigned: skip reads whose barcode isn't in
+            ``barcode_to_group``. If ``False``, write them to a
+            ``"_unassigned.pairs.gz"`` file.
+
+    Returns:
+        ``{group_name: output_path}``. Writes one file per group that
+        actually got at least one read.
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    if isinstance(barcode_to_group, pd.Series):
+        bc2g: Dict[str, str] = barcode_to_group.to_dict()
+    else:
+        bc2g = dict(barcode_to_group)
+
+    if extract_barcode is None:
+        extract_barcode = _default_extract_barcode
+
+    suffix = ".pairs.gz" if gzip_output else ".pairs"
+    handles: Dict[str, io.TextIOBase] = {}
+    paths: Dict[str, Path] = {}
+    header_lines: list[str] = []
+
+    def _open_group(group: str) -> io.TextIOBase:
+        if group in handles:
+            return handles[group]
+        out = output_dir / f"{group}{suffix}"
+        fh = _open_text(out, "wt")
+        for h in header_lines:
+            fh.write(h)
+        handles[group] = fh
+        paths[group] = out
+        return fh
+
+    with _open_text(pairs_path, "rt") as fin:
+        for line in fin:
+            if line.startswith("#"):
+                header_lines.append(line)
+                continue
+            fields = line.rstrip("\n").split("\t")
+            if barcode_column is not None:
+                bc = fields[barcode_column - 1]
+            else:
+                bc = extract_barcode(fields[0])
+            group = bc2g.get(bc)
+            if group is None:
+                if drop_unassigned:
+                    continue
+                group = "_unassigned"
+            _open_group(group).write(line)
+
+    for fh in handles.values():
+        fh.close()
+    return paths
+
+
+def pseudobulk_by_celltype(
+    pairs_path: Union[str, Path],
+    barcode_to_group: Mapping[str, str],
+    chrom_sizes: Union[str, Path],
+    output_dir: Union[str, Path],
+    *,
+    binsize: int = 100_000,
+    barcode_column: Optional[int] = None,
+    extract_barcode: Optional[Callable[[str], str]] = None,
+    keep_pairs: bool = False,
+    balance: bool = True,
+) -> Dict[str, Path]:
+    """End-to-end: demux a multi-cell pairs file then build one cool per group.
+
+    Pipeline:
+
+    1. :func:`demux_pairs_by_barcode` splits ``pairs_path`` into one
+       pairs file per group.
+    2. ``epione.upstream.pairs_to_cool`` builds ``{group}.cool`` from
+       each pairs file at the chosen ``binsize``.
+    3. (Optional) ``epione.bulk.hic.balance_cool`` ICE-balances each
+       cool — needed for downstream :func:`cluster_correlation` /
+       :func:`epione.bulk.hic.compartments`.
+    4. Intermediate per-group pairs files are deleted unless
+       ``keep_pairs=True``.
+
+    Arguments:
+        pairs_path, barcode_to_group, barcode_column, extract_barcode:
+            forwarded to :func:`demux_pairs_by_barcode`.
+        chrom_sizes: tab-separated ``chrom\\tsize`` file, used by
+            ``pairs_to_cool``.
+        output_dir: where ``{group}.cool`` go (and the temporary
+            pairs files).
+        binsize: cool resolution in bp (Chang 2024 uses 100 kb for
+            the per-celltype maps in Fig 1).
+        keep_pairs: keep the demuxed ``.pairs.gz`` files alongside
+            the cools. Default deletes them.
+        balance: ICE-balance each cool. Default ``True``.
+
+    Returns:
+        ``{group_name: cool_path}``.
+    """
+    from epione.upstream import pairs_to_cool
+    from epione.bulk.hic import balance_cool
+
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    pairs_paths = demux_pairs_by_barcode(
+        pairs_path, barcode_to_group, output_dir,
+        barcode_column=barcode_column,
+        extract_barcode=extract_barcode,
+        gzip_output=True, drop_unassigned=True,
+    )
+
+    cool_paths: Dict[str, Path] = {}
+    for group, ppath in pairs_paths.items():
+        cool = output_dir / f"{group}.cool"
+        pairs_to_cool(ppath, chrom_sizes, cool, binsize=int(binsize))
+        if balance:
+            balance_cool(cool, mad_max=10, min_nnz=1, ignore_diags=0)
+        cool_paths[group] = cool
+        if not keep_pairs:
+            try:
+                ppath.unlink()
+            except OSError:
+                pass
+
+    return cool_paths

--- a/tests/test_single_hic_demux.py
+++ b/tests/test_single_hic_demux.py
@@ -1,0 +1,222 @@
+"""Tests for ``epione.single.hic`` Phase 2 — Droplet Hi-C demux,
+pseudobulk, and celltype × celltype correlation.
+
+Builds a synthetic multi-cell pairs file where each line encodes its
+cell barcode in the readID suffix (Chang 2024 convention). Three
+"celltypes" with deliberately different intra-chromosomal contact
+profiles are simulated; demux + pseudobulk should recover them and
+:func:`cluster_correlation` should rank within-celltype replicates
+above between-celltype.
+"""
+from __future__ import annotations
+
+import gzip
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+
+pytest.importorskip("cooler")
+pytest.importorskip("cooltools")
+pytest.importorskip("matplotlib")
+pytest.importorskip("pysam")
+
+
+def _write_synthetic_droplet_pairs(
+    tmp_path: Path,
+    seed: int = 0,
+):
+    """Write a Droplet-Hi-C-style multi-cell pairs file.
+
+    Three celltypes A, B, C; two cells per celltype (6 cells total).
+    Each celltype emits contacts biased toward a different anchor
+    region on the same chromosome — so per-celltype pseudobulk maps
+    differ in a way correlation should resolve.
+    """
+    import pysam
+
+    rng = np.random.default_rng(seed)
+    chrom = "chr1"
+    size = 4_000_000
+    sizes = tmp_path / "chrom.sizes"
+    sizes.write_text(f"{chrom}\t{size}\n")
+
+    # Two cells per celltype, three celltypes. Barcodes are single
+    # underscore-free tokens so the default ``_``-split barcode
+    # extractor pulls them off readID cleanly.
+    cells = {
+        "Acell1": "A", "Acell2": "A",
+        "Bcell1": "B", "Bcell2": "B",
+        "Ccell1": "C", "Ccell2": "C",
+    }
+    # Celltype-specific anchor windows on chr1
+    anchors = {
+        "A": (   200_000, 1_000_000),
+        "B": ( 1_500_000, 2_300_000),
+        "C": ( 2_800_000, 3_700_000),
+    }
+    n_per_cell = 4_000
+
+    pairs_plain = tmp_path / "droplet.pairs"
+    rid = 0
+    with pairs_plain.open("w") as fh:
+        fh.write("## pairs format v1.0\n")
+        fh.write(f"#chromsize: {chrom} {size}\n")
+        fh.write(
+            "#columns: readID chrom1 pos1 chrom2 pos2 strand1 strand2\n"
+        )
+        for cell, ct in cells.items():
+            anc_lo, anc_hi = anchors[ct]
+            for _ in range(n_per_cell):
+                # Half within celltype anchor, half uniform background.
+                if rng.random() < 0.7:
+                    p1 = rng.integers(anc_lo, anc_hi)
+                    p2 = rng.integers(anc_lo, anc_hi)
+                else:
+                    p1 = rng.integers(0, size)
+                    p2 = rng.integers(0, size)
+                if p1 > p2:
+                    p1, p2 = p2, p1
+                # readID = "cellname_BARCODE" — Chang convention; we
+                # use the cell name as the "barcode" string here.
+                read_id = f"r{rid}_{cell}"
+                fh.write(
+                    f"{read_id}\t{chrom}\t{p1}\t{chrom}\t{p2}\t+\t+\n"
+                )
+                rid += 1
+
+    pairs_gz = tmp_path / "droplet.pairs.gz"
+    pysam.tabix_compress(str(pairs_plain), str(pairs_gz), force=True)
+
+    barcode_to_celltype = {cell: ct for cell, ct in cells.items()}
+    return pairs_gz, sizes, barcode_to_celltype, cells
+
+
+def test_demux_pairs_by_barcode_round_trips(tmp_path):
+    """Every input line must end up in exactly one output file."""
+    import epione as epi
+    pairs, sizes, bc2ct, cells = _write_synthetic_droplet_pairs(tmp_path)
+
+    out_dir = tmp_path / "demux"
+    paths = epi.single.hic.demux_pairs_by_barcode(
+        pairs, bc2ct, out_dir,
+    )
+    # 3 celltypes
+    assert set(paths.keys()) == {"A", "B", "C"}
+    for p in paths.values():
+        assert p.exists() and str(p).endswith(".pairs.gz")
+
+    # Body line count across outputs == input body line count
+    def _body_count(p):
+        n = 0
+        with gzip.open(p, "rt") as fh:
+            for line in fh:
+                if not line.startswith("#"):
+                    n += 1
+        return n
+
+    in_count = _body_count(pairs)
+    out_count = sum(_body_count(p) for p in paths.values())
+    assert out_count == in_count, (
+        f"line count mismatch: in={in_count}, out={out_count}"
+    )
+
+
+def test_demux_drops_unassigned_barcodes(tmp_path):
+    """Reads whose barcode isn't in the mapping must be dropped (default)."""
+    import epione as epi
+    pairs, sizes, bc2ct, cells = _write_synthetic_droplet_pairs(tmp_path)
+
+    # Map only celltype A cells; everything else should be dropped.
+    partial = {bc: ct for bc, ct in bc2ct.items() if ct == "A"}
+    out_dir = tmp_path / "demux_partial"
+    paths = epi.single.hic.demux_pairs_by_barcode(
+        pairs, partial, out_dir, drop_unassigned=True,
+    )
+    assert set(paths.keys()) == {"A"}
+
+
+def test_pseudobulk_by_celltype_builds_balanced_cools(tmp_path):
+    """End-to-end: 3 celltypes → 3 balanced cools."""
+    import cooler
+    import epione as epi
+
+    pairs, sizes, bc2ct, _ = _write_synthetic_droplet_pairs(tmp_path)
+    out_dir = tmp_path / "pseudobulk"
+    cools = epi.single.hic.pseudobulk_by_celltype(
+        pairs, bc2ct, sizes, out_dir, binsize=100_000, balance=True,
+    )
+    assert set(cools.keys()) == {"A", "B", "C"}
+    for ct, c in cools.items():
+        clr = cooler.Cooler(str(c))
+        assert "weight" in clr.bins().columns, (
+            f"{ct}: cool was not ICE-balanced"
+        )
+        # And pixel count > 0 — the demuxed pairs landed.
+        assert len(clr.pixels()[:]) > 0
+
+
+def test_cluster_correlation_recovers_celltype_structure(tmp_path):
+    """Within-celltype replicates should correlate higher than between."""
+    import epione as epi
+
+    pairs, sizes, bc2ct, _ = _write_synthetic_droplet_pairs(tmp_path)
+
+    # Replicate split: cell1 vs cell2 of each celltype get separate cools
+    # so the resulting 6×6 correlation matrix should show A1-A2, B1-B2,
+    # C1-C2 as the strongest off-diagonal pairs.
+    bc2rep = {cell: f"{ct}rep{cell[-1]}" for cell, ct in bc2ct.items()}
+    # bc2rep maps each barcode to an own group label (one cell each)
+    # so the 6 groups are A_cell1, A_cell2, B_cell1, ...
+
+    out_dir = tmp_path / "rep"
+    cools = epi.single.hic.pseudobulk_by_celltype(
+        pairs, bc2rep, sizes, out_dir, binsize=100_000, balance=True,
+    )
+    # Drop empty bin combos: ensure every cool has > 0 contacts
+    assert len(cools) == 6
+
+    corr, names = epi.single.hic.cluster_correlation(
+        cools, chromosomes=["chr1"], balance=True, log=True,
+    )
+    assert corr.shape == (6, 6)
+    assert list(corr.index) == names
+    # Diagonal should be ~1
+    assert np.allclose(np.diag(corr.to_numpy()), 1.0, atol=1e-6)
+
+    M = corr.to_numpy()
+    # Group label format is ``"{celltype}rep{N}"`` (e.g. "Arep1");
+    # the celltype letter is the leading character.
+    cts = [n[0] for n in names]
+    within: list[float] = []
+    between: list[float] = []
+    for i in range(len(names)):
+        for j in range(i + 1, len(names)):
+            (within if cts[i] == cts[j] else between).append(M[i, j])
+    assert np.mean(within) > np.mean(between), (
+        f"within-celltype mean r ({np.mean(within):.3f}) should exceed "
+        f"between-celltype mean r ({np.mean(between):.3f})"
+    )
+
+
+def test_plot_correlation_heatmap_renders(tmp_path):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    import epione as epi
+
+    # Build a tiny 4×4 correlation matrix manually
+    M = np.array([
+        [1.0, 0.85, 0.20, 0.18],
+        [0.85, 1.0, 0.22, 0.21],
+        [0.20, 0.22, 1.0, 0.78],
+        [0.18, 0.21, 0.78, 1.0],
+    ])
+    df = pd.DataFrame(M, index=["A1", "A2", "B1", "B2"],
+                      columns=["A1", "A2", "B1", "B2"])
+
+    fig, ax, img = epi.pl.plot_correlation_heatmap(df, figsize=(3.5, 3.0))
+    assert fig is not None
+    plt.close(fig)


### PR DESCRIPTION
## Summary

Adds the three Droplet-Hi-C primitives needed to take a multi-cell `.pairs` file (Chang 2024 Fig 1 input) all the way to a per-celltype contact-map comparison. With this PR plus #30 (loops/APA), the entire Chang 2024 Fig 1 d/e/f/g/h pipeline is achievable using only epione APIs.

* `epione.single.hic.demux_pairs_by_barcode` — stream a `.pairs` / `.pairs.gz` line-by-line, extract the cell barcode from readID (Chang convention: trailing `_BARCODE`) or a configurable column, and split into one pairs file per group via `barcode_to_group`. Header lines (`##`, `#chromsize:`, `#columns:`) are propagated into every output.
* `epione.single.hic.pseudobulk_by_celltype` — end-to-end: demux → `epione.upstream.pairs_to_cool` → `epione.bulk.hic.balance_cool`, giving one balanced `.cool` per celltype/cluster.
* `epione.single.hic.cluster_correlation` — for a dict of celltype cools, flatten the (balanced, log2) cis upper-triangle into a vector per celltype and return the Pearson correlation DataFrame + name list. Reproduces Chang 2024 Fig 1f.
* `epione.pl.plot_correlation_heatmap` — symmetric RdBu_r heatmap with per-cell value annotations, designed for Chang Fig 1f's small-N (≤ ~20 celltypes) layout.

## Why this PR

Closes the gap between scHiCluster cell embedding (already in `single.hic`) and the per-celltype downstream analyses required by Chang 2024 Fig 1 — the only "missing pieces" were demux and pairwise correlation. The Droplet-Hi-C tutorial (next PR) will chain `pseudobulk_by_celltype` → `compartments` (#27) / `loops` (#30) / `cluster_correlation` to reproduce d/e/f/g/h end-to-end.

## Test plan

- [x] `tests/test_single_hic_demux.py` — 5 new tests on a synthetic Droplet-Hi-C-style multi-cell pairs file with 3 celltypes (2 cells each) and celltype-specific anchor regions:
    - demux round-trips line counts (every input line lands in exactly one output);
    - drops barcodes absent from the mapping when configured to;
    - `pseudobulk_by_celltype` produces 3 ICE-balanced cools with non-empty pixel tables;
    - `cluster_correlation` on the 6 single-cell pseudobulks recovers celltype structure (within-celltype mean r > between-celltype);
    - `plot_correlation_heatmap` renders.
- [x] Full suite: 78 → 83 tests passing locally (`pytest -x -q`).
- [ ] CI green on Python 3.10/3.11.

🤖 Generated with [Claude Code](https://claude.com/claude-code)