### PR TITLE
tutorial(differential-peaks): add genomic-feature annotation section

### DIFF
--- a/epione_guide/tutorials/bulk/t_differential_peaks.ipynb
+++ b/epione_guide/tutorials/bulk/t_differential_peaks.ipynb
@@ -693,6 +693,100 @@
     "where small-count numerical noise moves a few peaks in and out of the\n",
     "top set."
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "74b8047d",
+   "metadata": {},
+   "source": [
+    "## 8 · Where do the closing peaks sit? — genomic-feature annotation\n",
+    "\n",
+    "\"Which peaks changed\" is only half the answer; **where** a peak sits\n",
+    "relative to genes is what makes the change interpretable. A factor\n",
+    "losing **promoter-proximal** accessibility acts at transcription start\n",
+    "sites directly; one losing **distal / intronic** accessibility acts\n",
+    "through enhancers.\n",
+    "\n",
+    "`epi.utils.annotate_peaks` assigns each peak one genomic-feature class —\n",
+    "promoter / exon / intron / intergenic — from a GTF, with a precedence\n",
+    "rule (promoter > exon > intron > intergenic) so the four classes\n",
+    "partition the peak set. `epi.utils.peak_feature_enrichment` then tests,\n",
+    "per class with Fisher's exact, which class is over- or under-represented\n",
+    "among the differential peaks relative to a background — here the\n",
+    "**unchanged** peaks, which controls for the assay's baseline genomic\n",
+    "distribution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1d543e1b",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "genomic-feature class of every tested peak:\n",
+      "feature\n",
+      "intergenic    9114\n",
+      "intron        8384\n",
+      "promoter      2033\n",
+      "exon           310\n",
+      "Name: count, dtype: int64\n"
+     ]
+    }
+   ],
+   "source": [
+    "# res_coord (from section 6) carries chrom/start/end for every tested peak.\n",
+    "res_coord['closing'] = (res_coord['padj'] < 0.05) & (res_coord['log2FoldChange'] < -1)\n",
+    "\n",
+    "ann = epi.utils.annotate_peaks(res_coord, GENCODE_GTF)\n",
+    "print('genomic-feature class of every tested peak:')\n",
+    "print(ann['feature'].value_counts())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "75d4f5ef",
+   "metadata": {},
+   "outputs": [
+    {
+     "output_type": "stream",
+     "name": "stdout",
+     "text": [
+      "   feature  fg_count  fg_frac  bg_count  bg_frac  enrichment       pvalue          fdr\n",
+      "  promoter        25 0.017895      2008 0.108870    0.164375 5.115636e-38 2.046254e-37\n",
+      "    intron       717 0.513243      7667 0.415691    1.234674 1.581808e-12 3.163616e-12\n",
+      "      exon        34 0.024338       276 0.014964    1.626404 9.701833e-03 1.293578e-02\n",
+      "intergenic       621 0.444524      8493 0.460475    0.965360 2.537181e-01 2.537181e-01\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Foreground = significant closing peaks; background = peaks that did not change.\n",
+    "enr = epi.utils.peak_feature_enrichment(\n",
+    "    ann[ann['closing']], ann[~ann['closing']], GENCODE_GTF)\n",
+    "print(enr[['feature', 'fg_count', 'fg_frac', 'bg_count', 'bg_frac',\n",
+    "           'enrichment', 'pvalue', 'fdr']].to_string(index=False))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b1916864",
+   "metadata": {},
+   "source": [
+    "The closing peaks are **strongly depleted at promoters** (enrichment\n",
+    "0.16, FDR ~ 2e-37) and **enriched in introns** (1.23, FDR ~ 3e-12).\n",
+    "OTX2-KD therefore does not shut down promoters — it removes\n",
+    "accessibility from **distal, intronic regulatory elements**, the\n",
+    "signature of an enhancer-acting transcription factor. This is the same\n",
+    "conclusion section 6 reached gene by gene (\"OTX2-bound genes lose their\n",
+    "enhancers\"), now quantified genome-wide as a feature-class enrichment\n",
+    "test: the *direction* of the regulatory mechanism falls straight out of\n",
+    "the annotation."
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary

Adds **section 8** to `t_differential_peaks` demonstrating the
`annotate_peaks` / `peak_feature_enrichment` functions (added in #34):

- `epi.utils.annotate_peaks` — assigns each tested peak one
  genomic-feature class (promoter / exon / intron / intergenic).
- `epi.utils.peak_feature_enrichment` — Fisher's exact test of which
  class is over/under-represented among the closing peaks vs the
  unchanged background.

On the OTX2-KD ATAC data the closing peaks come out strongly
promoter-depleted (enrichment 0.16) and intron-enriched (1.23) —
quantifying genome-wide the enhancer-acting mechanism that section 6
showed gene by gene.

Pure addition — 4 new cells appended (markdown + 2 code + markdown);
no existing cell modified. Cells executed against the tutorial's own
OTX2 data; outputs included.

## Test plan

- [x] `nbformat.validate` passes (26 cells)
- [x] new cells executed; outputs are real