### PR TITLE
feat(tl): one-sided option for the Poisson differential backend

### DIFF
--- a/epione/tl/_differential.py
+++ b/epione/tl/_differential.py
@@ -447,15 +447,32 @@ def _require_replicates(counts_df, meta, contrast, backend):
 
 
 def _run_poisson(counts_df, meta, contrast, *, pseudocount: float = 0.5,
-                 **_kwargs) -> pd.DataFrame:
+                 alternative: str = "two-sided", **_kwargs) -> pd.DataFrame:
     """No-replicate differential test.
 
     Pools (sums) the replicate counts of each condition and applies a
     per-region **exact binomial test** of the foreground count against the
     library-size-expected proportion — the standard one-vs-one ChIP-seq /
     ATAC-seq comparison when there is no replication to estimate dispersion.
+
+    ``alternative`` sets the test direction and should match the question:
+
+    - ``'two-sided'`` (default) — test for **any** change; use when the
+      question is "what changed" / "is there a difference".
+    - ``'less'`` — test only for a **decrease** in the first contrast
+      level (``log2FoldChange < 0``); use for a directional question
+      such as "which regions are *reduced* / *lost*".
+    - ``'greater'`` — test only for an **increase** in the first contrast
+      level; use for "which regions are *gained* / *increased*".
+
+    A one-sided test is the correct, more powerful choice when the
+    question itself is directional — it is not p-hacking, because the
+    direction was fixed by the question before the data was seen.
     """
     from scipy.stats import binomtest
+    if alternative not in ("two-sided", "less", "greater"):
+        raise ValueError(
+            "alternative must be 'two-sided', 'less' or 'greater'")
     factor, level_a, level_b = contrast
     a_idx = meta.index[meta[factor].astype(str) == str(level_a)]
     b_idx = meta.index[meta[factor].astype(str) == str(level_b)]
@@ -475,7 +492,8 @@ def _run_poisson(counts_df, meta, contrast, *, pseudocount: float = 0.5,
     pvals = np.ones(len(a), dtype=float)
     for i in range(len(a)):
         if tot[i] > 0:
-            pvals[i] = binomtest(int(a_int[i]), int(tot[i]), p0).pvalue
+            pvals[i] = binomtest(int(a_int[i]), int(tot[i]), p0,
+                                 alternative=alternative).pvalue
     log2fc = np.log2(((a + pseudocount) / lib_a) /
                      ((b + pseudocount) / lib_b))
     base = (a / lib_a + b / lib_b) * (0.5e6)        # mean CPM (baseMean role)

--- a/tests/test_differential_quant.py
+++ b/tests/test_differential_quant.py
@@ -73,6 +73,31 @@ def test_poisson_backend_ranks_planted_top():
     assert recall >= 0.7, f"poisson recovered only {recall:.0%} of planted"
 
 
+def test_poisson_backend_one_sided():
+    """alternative='less' flags only the planted-down regions; the
+    planted-up regions stay non-significant under a depletion-only test."""
+    counts, meta, (n_up, n_dn) = _make_one_vs_one()
+    res = differential_peaks(
+        counts=counts, metadata=meta,
+        contrast=("condition", "trt", "ctrl"), backend="poisson",
+        alternative="less", min_count=5, min_samples=1, quiet=True,
+    )
+    dn = res.loc[[f"region_{i + n_up}" for i in range(n_dn)], "padj"]
+    up = res.loc[[f"region_{i}" for i in range(n_up)], "padj"]
+    assert (dn < 0.05).mean() > 0.7, "planted-down not caught by 'less'"
+    assert (up > 0.5).mean() > 0.7, "planted-up wrongly flagged by 'less'"
+
+
+def test_poisson_backend_rejects_bad_alternative():
+    counts, meta, _ = _make_one_vs_one(n_features=120)
+    with pytest.raises(ValueError, match="alternative"):
+        differential_peaks(
+            counts=counts, metadata=meta,
+            contrast=("condition", "trt", "ctrl"), backend="poisson",
+            alternative="lower", quiet=True,
+        )
+
+
 def test_count_backends_reject_no_replicate_design():
     """pydeseq2 / edgepy must refuse a one-vs-one design and name the
     poisson backend in the error."""


### PR DESCRIPTION
## Summary

`differential_peaks(backend='poisson')` now accepts
`alternative='two-sided'` (default) `| 'less' | 'greater'`, forwarded to
the per-region exact binomial test.

A **directional** question — "which regions are *reduced* / *lost*" or
"*gained* / *increased*" — calls for the matching one-sided test. It is
the correct and more powerful choice because the direction was fixed by
the question before the data was seen (not chosen post-hoc).

## Test plan

- [x] `test_poisson_backend_one_sided` — `alternative='less'` flags only
  the planted-down regions, leaves planted-up non-significant.
- [x] `test_poisson_backend_rejects_bad_alternative`.
- [x] Full `test_differential_quant.py` green (11 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)